### PR TITLE
Set GOCACHE to location non-root can write to

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,10 @@ ENV WPT_PATH="${HOME}/web-platform-tests"
 RUN mkdir -p "${GO_REPO_PATH}"
 RUN mkdir -p "${WPT_PATH}"
 
+# Ensure golang cache is in /go, which will be chowned to unprivileged $USER on
+# instance start.`
+ENV GOCACHE="/go/.cache"
+
 RUN apk update
 RUN apk add bash git make
 


### PR DESCRIPTION
This avoids the following warning during build inside Docker container:

```
go: disabling cache (/.cache/go-build) due to initialization failure: mkdir /.cache: permission denied
```

@lukebjerring PTAL