### PR TITLE
Migrate to wpt.fyi/shared

### DIFF
--- a/metrics/models.go
+++ b/metrics/models.go
@@ -7,7 +7,7 @@ package metrics
 import (
 	"time"
 
-	base "github.com/w3c/wptdashboard/shared"
+	base "github.com/web-platform-tests/wpt.fyi/shared"
 )
 
 // ByCreatedDate sorts tests by run's CreatedAt date (descending)

--- a/metrics/models_test.go
+++ b/metrics/models_test.go
@@ -12,7 +12,7 @@ import (
 	"fmt"
 
 	"github.com/stretchr/testify/assert"
-	models "github.com/w3c/wptdashboard/shared"
+	models "github.com/web-platform-tests/wpt.fyi/shared"
 )
 
 var today = time.Date(2018, 1, 4, 0, 0, 0, 0, time.UTC)


### PR DESCRIPTION
For https://github.com/web-platform-tests/wpt.fyi/issues/44

This may temporarily break wpt.fyi which also relies on `/shared` itself.