### PR TITLE
Add rate limiting

### DIFF
--- a/metrics/storage/storage.go
+++ b/metrics/storage/storage.go
@@ -24,7 +24,12 @@ import (
 	"github.com/web-platform-tests/results-analysis/metrics"
 	base "github.com/web-platform-tests/wpt.fyi/shared"
 	"golang.org/x/net/context"
+	"golang.org/x/time/rate"
 	"google.golang.org/api/iterator"
+)
+
+var (
+	limiter = rate.NewLimiter(50, 50)
 )
 
 type OutputLocation struct {
@@ -383,6 +388,9 @@ func processTestRun(ctx *GCSDatastoreContext, testRun *base.TestRun,
 func loadTestResults(ctx *GCSDatastoreContext, testRun *base.TestRun,
 	objName string, resultChan chan metrics.TestRunResults,
 	errChan chan error) {
+	// Rate limit.
+	limiter.Wait(ctx.Context)
+
 	// Read object from GCS
 	obj := ctx.Bucket.Handle.Object(objName)
 	reader, err := obj.NewReader(ctx.Context)


### PR DESCRIPTION
## Description
Adds rate limiting to the collector (client-side), so that the server doesn't throttle us.

Sets a rate limiter for https://github.com/web-platform-tests/results-collection/issues/454 of 50 req/s, which (for a fresh run) takes ~30m (~100k files / 50req/s / 60s).

This is based on the 3000 req/m quota described here.

## Review Information
`go run metrics/run/collect_metrics.go`