### PR TITLE
Add caching to fetched files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/metrics/run/cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,13 @@ services:
 
 before_install: ./docker_build.sh && ./docker_start.sh
 
-install: |
-  source ./docker_env.sh
-  docker exec -t -u "$(id -u ${USER}):$(id -g ${USER})" "${INSTANCE_NAME}" make build
+install:
+- source ./docker_env.sh
+- docker exec -t -u "$(id -u ${USER}):$(id -g ${USER})" "${INSTANCE_NAME}" make build
 
-script: |
-  source ./docker_env.sh
-  docker exec -t -u "$(id -u ${USER}):$(id -g ${USER})" "${INSTANCE_NAME}" make test
-  docker exec -t -u "$(id -u ${USER}):$(id -g ${USER})" "${INSTANCE_NAME}" make lint
+script:
+- source ./docker_env.sh
+- docker exec -t -u "$(id -u ${USER}):$(id -g ${USER})" "${INSTANCE_NAME}" make test
+- docker exec -t -u "$(id -u ${USER}):$(id -g ${USER})" "${INSTANCE_NAME}" make lint
 
 after_script: ./docker_stop.sh

--- a/metrics/compute/compute.go
+++ b/metrics/compute/compute.go
@@ -28,6 +28,14 @@ func OkAndUnknownOrPasses(status *metrics.CompleteTestStatus) bool {
 			status.SubStatus == metrics.SubTestStatusPass)
 }
 
+func OkOrPassesAndUnknownOrPasses(status *metrics.CompleteTestStatus) bool {
+	return (status.Status == metrics.TestStatusOK ||
+		status.Status == metrics.TestStatusPass) &&
+		(status.SubStatus ==
+			metrics.SubTestStatusUnknown ||
+			status.SubStatus == metrics.SubTestStatusPass)
+}
+
 // Gather results from test runs into input format for Compute* functions in
 // this module.
 func GatherResultsById(allResults *[]metrics.TestRunResults) (

--- a/metrics/compute/compute_test.go
+++ b/metrics/compute/compute_test.go
@@ -189,7 +189,7 @@ func TestGatherResultsById_OneRun_SubTest(t *testing.T) {
 	}, gathered[metrics.TestID{"A test", subName2}][runA])
 }
 
-func TestComputeTotals(t *testing.T) {
+func getPrecomputedStatusz() *TestRunsStatus {
 	statusz := make(TestRunsStatus)
 	status1 := metrics.CompleteTestStatus{
 		metrics.TestStatusFromString("OK"),
@@ -197,6 +197,10 @@ func TestComputeTotals(t *testing.T) {
 	}
 	status2 := metrics.CompleteTestStatus{
 		metrics.TestStatusFromString("ERROR"),
+		metrics.SubTestStatusFromString("STATUS_UNKNOWN"),
+	}
+	status3 := metrics.CompleteTestStatus{
+		metrics.TestStatusFromString("PASS"),
 		metrics.SubTestStatusFromString("STATUS_UNKNOWN"),
 	}
 	subStatus1 := metrics.CompleteTestStatus{
@@ -221,13 +225,19 @@ func TestComputeTotals(t *testing.T) {
 	statusz[ac1z] = make(map[shared.TestRun]metrics.CompleteTestStatus)
 	statusz[ab1][runA] = status1
 	statusz[ab1][runB] = status2
-	statusz[ab2][runB] = status1
+	statusz[ab2][runB] = status3
 	statusz[ac1][runA] = status1
 	statusz[ac1x][runA] = subStatus1
 	statusz[ac1y][runA] = subStatus2
 	statusz[ac1z][runA] = subStatus2
 
-	totals := ComputeTotals(&statusz)
+	return &statusz
+}
+
+func TestComputeTotals(t *testing.T) {
+	statusz := getPrecomputedStatusz()
+
+	totals := ComputeTotals(statusz)
 	assert.Equal(t, 6, len(totals))   // a, a/b, a/c, a/b/1, a/b/2, a/c/1.
 	assert.Equal(t, 6, totals["a"])   // a/b/1, a/b/2, a/c/1, a/c/1:x, a/c/1:y, a/c/1:z.
 	assert.Equal(t, 2, totals["a/b"]) // a/b/1, a/b/2.
@@ -235,4 +245,27 @@ func TestComputeTotals(t *testing.T) {
 	assert.Equal(t, 1, totals["a/b/2"])
 	assert.Equal(t, 4, totals["a/c"])   // a/c/1, a/c/1:x, a/c/1:y, a/c/1:z.
 	assert.Equal(t, 4, totals["a/c/1"]) // a/c/1, a/c/1:x, a/c/1:y, a/c/1:z.
+}
+
+func TestComputePassRateMetric(t *testing.T) {
+	statusz := getPrecomputedStatusz()
+
+	noTopLevelPasses := ComputePassRateMetric(2, statusz, OkAndUnknownOrPasses)
+	topLevelPasses := ComputePassRateMetric(2, statusz, OkOrPassesAndUnknownOrPasses)
+
+	assert.Equal(t, 6, len(noTopLevelPasses))
+	assert.Equal(t, 6, len(topLevelPasses))
+
+	// a/b/1: runA=OK, runB=ERROR.
+	assert.Equal(t, []int{0, 1, 0}, noTopLevelPasses["a/b/1"])
+	assert.Equal(t, []int{0, 1, 0}, topLevelPasses["a/b/1"])
+
+	// a/c/1: runA=OK.
+	assert.Equal(t, []int{2, 2, 0}, noTopLevelPasses["a/c/1"])
+	assert.Equal(t, []int{2, 2, 0}, topLevelPasses["a/c/1"])
+
+	// a/b/2: runB=PASS (and not OK): leads to [1, 0, 0].
+	assert.Equal(t, []int{1, 0, 0}, noTopLevelPasses["a/b/2"])
+	// a/b/2: runB=PASS acceptable; leads to [0, 1, 0].
+	assert.Equal(t, []int{0, 1, 0}, topLevelPasses["a/b/2"])
 }

--- a/metrics/models.go
+++ b/metrics/models.go
@@ -89,6 +89,9 @@ const (
 
 	// TestStatusTimeout indicates that some tests timed out.
 	TestStatusTimeout TestStatus = 3
+
+	// TestStatusPass indicates that all tests completed successfully and passed.
+	TestStatusPass TestStatus = 4
 )
 
 var testStatusNames = map[int32]string{
@@ -96,6 +99,7 @@ var testStatusNames = map[int32]string{
 	1: "TEST_OK",
 	2: "TEST_ERROR",
 	3: "TEST_TIMEOUT",
+	4: "TEST_PASS",
 }
 
 var testStatusValues = map[string]int32{
@@ -103,6 +107,7 @@ var testStatusValues = map[string]int32{
 	"TEST_OK":             1,
 	"TEST_ERROR":          2,
 	"TEST_TIMEOUT":        3,
+	"TEST_PASS":           4,
 }
 
 // TestStatusFromString produces a TestStatus value from a name.

--- a/metrics/run/collect_metrics.go
+++ b/metrics/run/collect_metrics.go
@@ -148,6 +148,7 @@ Data collection procedure:
 */
 
 func main() {
+	flag.Parse()
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
 
 	logFileName := "current_metrics.log"

--- a/metrics/run/collect_metrics.go
+++ b/metrics/run/collect_metrics.go
@@ -204,7 +204,7 @@ func main() {
 	go func() {
 		defer wg.Done()
 		passRateMetric = compute.ComputePassRateMetric(len(runs),
-			&resultsById, compute.OkAndUnknownOrPasses)
+			&resultsById, compute.OkOrPassesAndUnknownOrPasses)
 	}()
 	for _, run := range runs {
 		go func(browserName string) {
@@ -213,7 +213,7 @@ func main() {
 			failuresMetrics[browserName] =
 				compute.ComputeBrowserFailureList(len(runs),
 					browserName, &resultsById,
-					compute.OkAndUnknownOrPasses)
+					compute.OkOrPassesAndUnknownOrPasses)
 		}(run.BrowserName)
 	}
 	wg.Wait()

--- a/metrics/run/collect_metrics.go
+++ b/metrics/run/collect_metrics.go
@@ -286,7 +286,7 @@ func main() {
 	for _, outputter := range outputters {
 		go func(outputter storage.Outputter) {
 			defer wg.Done()
-			outputId := storage.OutputId{
+			outputID := storage.OutputID{
 				MetadataLocation: storage.OutputLocation{
 					BQDatasetName: *outputBQMetadataDataset,
 					BQTableName:   *outputBQPassRateMetadataTable,
@@ -298,7 +298,7 @@ func main() {
 				},
 			}
 			_, _, errs := uploadTotalsAndPassRateMetric(
-				&passRateMetadata, outputter, outputId, totals,
+				&passRateMetadata, outputter, outputID, totals,
 				passRateMetric)
 			processUploadErrors(errs)
 		}(outputter)
@@ -312,7 +312,7 @@ func main() {
 					DataURL:     failuresUrlf(browserName),
 					BrowserName: browserName,
 				}
-				outputId := storage.OutputId{
+				outputID := storage.OutputID{
 					MetadataLocation: storage.OutputLocation{
 						BQDatasetName: *outputBQMetadataDataset,
 						BQTableName:   *outputBQFailuresMetadataTable,
@@ -327,7 +327,7 @@ func main() {
 					},
 				}
 				_, _, errs := uploadFailureLists(&failuresMetadata,
-					outputter, outputId, browserName,
+					outputter, outputID, browserName,
 					failuresMetric)
 				processUploadErrors(errs)
 			}(browserName, failuresMetric, outputter)
@@ -398,7 +398,7 @@ func totalsAndPassRateMetricToRows(totals map[string]int,
 }
 
 func uploadTotalsAndPassRateMetric(metricsRun *metrics.PassRateMetadata,
-	outputter storage.Outputter, id storage.OutputId,
+	outputter storage.Outputter, id storage.OutputID,
 	totals map[string]int, passRateMetric map[string][]int) (
 	interface{}, []interface{}, []error) {
 	rows := totalsAndPassRateMetricToRows(totals, passRateMetric)
@@ -406,7 +406,7 @@ func uploadTotalsAndPassRateMetric(metricsRun *metrics.PassRateMetadata,
 }
 
 func uploadFailureLists(metricsRun *metrics.FailuresMetadata,
-	outputter storage.Outputter, id storage.OutputId,
+	outputter storage.Outputter, id storage.OutputID,
 	browserName string, failureLists [][]metrics.TestID) (
 	interface{}, []interface{}, []error) {
 	rows := failureListsToRows(browserName, failureLists)

--- a/metrics/storage/storage.go
+++ b/metrics/storage/storage.go
@@ -31,6 +31,7 @@ import (
 	"google.golang.org/api/iterator"
 )
 
+const cacheFolderPermissions = 0755
 const cacheFilePermissions = 0644
 
 type OutputLocation struct {
@@ -275,7 +276,7 @@ func LoadTestRunResults(ctx *GCSDatastoreContext, runs []base.TestRun) (
 
 	if *cachePath != "" {
 		if _, statErr := os.Stat(*cachePath); os.IsNotExist(statErr) {
-			if err := os.MkdirAll(*cachePath, cacheFilePermissions); err != nil {
+			if err := os.MkdirAll(*cachePath, cacheFolderPermissions); err != nil {
 				log.Fatalf("Failed to create cache dir %s: %s", *cachePath, err.Error())
 			}
 		}
@@ -474,7 +475,7 @@ func writeCacheFile(filename string, data []byte) error {
 	func() {
 		pieces := strings.Split(filename, "/")
 		parentDir := strings.Join(pieces[:len(pieces)-1], "/")
-		if err := os.MkdirAll(parentDir, cacheFilePermissions); err != nil {
+		if err := os.MkdirAll(parentDir, cacheFolderPermissions); err != nil {
 			log.Printf("Failed to make parent dir %s", parentDir)
 		}
 	}()

--- a/metrics/storage/storage.go
+++ b/metrics/storage/storage.go
@@ -9,9 +9,12 @@ import (
 	"compress/gzip"
 	"encoding/json"
 	"errors"
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"log"
+	"os"
+	"path"
 	"reflect"
 	"sort"
 	"strings"
@@ -28,10 +31,6 @@ import (
 	"google.golang.org/api/iterator"
 )
 
-var (
-	limiter = rate.NewLimiter(50, 50)
-)
-
 type OutputLocation struct {
 	GCSObjectPath string
 	BQDatasetName string
@@ -46,6 +45,12 @@ type OutputId struct {
 type Outputter interface {
 	Output(OutputId, interface{}, []interface{}) (interface{}, []interface{}, []error)
 }
+
+var (
+	cachePath        = flag.String("cache_path", "", "Path to cache the GCS objects. If empty, fetches are not cached.")
+	rateLimitFetches = flag.Bool("rate_limit", true, "Whether to rate limit the file fetches (Default: true)")
+	limiter          = rate.NewLimiter(50, 50)
+)
 
 // Encapsulate bucket name and handle; both are needed for some storage
 // read/write routines.
@@ -265,6 +270,15 @@ func (ctx BQContext) Output(id OutputId, metadata interface{},
 // context to load data from bucket.
 func LoadTestRunResults(ctx *GCSDatastoreContext, runs []base.TestRun) (
 	runResults []metrics.TestRunResults) {
+
+	if *cachePath != "" {
+		if _, statErr := os.Stat(*cachePath); os.IsNotExist(statErr) {
+			if err := os.MkdirAll(*cachePath, 0700); err != nil {
+				log.Fatalf("Failed to create cache dir %s: %s", *cachePath, err.Error())
+			}
+		}
+	}
+
 	resultChan := make(chan metrics.TestRunResults, 0)
 	errChan := make(chan error, 0)
 	runResults = make([]metrics.TestRunResults, 0, 100000)
@@ -388,49 +402,100 @@ func processTestRun(ctx *GCSDatastoreContext, testRun *base.TestRun,
 func loadTestResults(ctx *GCSDatastoreContext, testRun *base.TestRun,
 	objName string, resultChan chan metrics.TestRunResults,
 	errChan chan error) {
-	// Rate limit.
-	limiter.Wait(ctx.Context)
 
-	// Read object from GCS
-	obj := ctx.Bucket.Handle.Object(objName)
-	reader, err := obj.NewReader(ctx.Context)
-	if err != nil {
-		errChan <- err
-		return
+	var data []byte
+	var err error
+	if *cachePath != "" {
+		filename := path.Join(*cachePath, objName)
+		if data, err = loadCachedFile(filename); err != nil {
+			log.Printf("Error reading cached object %s", objName)
+			errChan <- err
+			return
+		}
 	}
-	defer reader.Close()
-	data, err := ioutil.ReadAll(reader)
-	if err != nil {
-		errChan <- err
-		return
+
+	if data == nil {
+		data, err = fetchFile(objName, ctx)
+		if err != nil {
+			if storage.ErrObjectNotExist == err {
+				return
+			}
+			log.Printf("Error fetching object %s", objName)
+			errChan <- err
+			return
+		}
+		if data == nil {
+			return
+		}
+		if *cachePath != "" {
+			err = writeCacheFile(path.Join(*cachePath, objName), data)
+			if err != nil {
+				log.Printf("Failed to write cache object %s", objName)
+				errChan <- err
+				return
+			}
+		}
 	}
 
 	// Unmarshal JSON, which may be gzipped.
 	var results metrics.TestResults
-	var anyResult interface{}
-	if err := json.Unmarshal(data, &anyResult); err != nil {
-		reader2 := bytes.NewReader(data)
-		reader3, err := gzip.NewReader(reader2)
-		if err != nil {
-			errChan <- err
-			return
-		}
+	jsonData := data
+
+	// Try unzip
+	reader2 := bytes.NewReader(data)
+	reader3, err := gzip.NewReader(reader2)
+	if err == nil {
 		defer reader3.Close()
 		unzippedData, err := ioutil.ReadAll(reader3)
 		if err != nil {
+			log.Printf("Error reading unzipped object %s", objName)
 			errChan <- err
 			return
 		}
-		if err := json.Unmarshal(unzippedData, &results); err != nil {
-			errChan <- err
-			return
-		}
-		resultChan <- metrics.TestRunResults{testRun, &results}
-	} else {
-		if err := json.Unmarshal(data, &results); err != nil {
-			errChan <- err
-			return
-		}
-		resultChan <- metrics.TestRunResults{testRun, &results}
+		jsonData = unzippedData
 	}
+
+	if err := json.Unmarshal(jsonData, &results); err != nil {
+		log.Printf("Error unmarshalling object %s", objName)
+		errChan <- err
+		return
+	}
+	resultChan <- metrics.TestRunResults{testRun, &results}
+}
+
+func loadCachedFile(filename string) ([]byte, error) {
+	if _, statErr := os.Stat(filename); os.IsNotExist(statErr) {
+		return nil, nil
+	}
+	return ioutil.ReadFile(filename)
+}
+
+func writeCacheFile(filename string, data []byte) error {
+	// Make parent dir(s).
+	func() {
+		pieces := strings.Split(filename, "/")
+		parentDir := strings.Join(pieces[:len(pieces)-1], "/")
+		if err := os.MkdirAll(parentDir, 0700); err != nil {
+			log.Printf("Failed to make parent dir %s", parentDir)
+		}
+	}()
+
+	// Write cache file.
+	return ioutil.WriteFile(filename, data, 0700)
+}
+
+func fetchFile(objName string, ctx *GCSDatastoreContext) ([]byte, error) {
+	// Rate limit.
+	if *rateLimitFetches {
+		limiter.Wait(ctx.Context)
+	}
+	// Read object from GCS
+	obj := ctx.Bucket.Handle.Object(objName)
+	reader, err := obj.NewReader(ctx.Context)
+	if err != nil {
+		log.Printf("Error loading object %s: %s", objName, err.Error())
+		return nil, err
+	}
+	defer reader.Close()
+	return ioutil.ReadAll(reader)
 }

--- a/metrics/storage/storage.go
+++ b/metrics/storage/storage.go
@@ -31,6 +31,10 @@ import (
 	"google.golang.org/api/iterator"
 )
 
+var (
+	limiter = rate.NewLimiter(50, 50)
+)
+
 type OutputLocation struct {
 	GCSObjectPath string
 	BQDatasetName string

--- a/metrics/storage/storage.go
+++ b/metrics/storage/storage.go
@@ -31,7 +31,7 @@ import (
 	"google.golang.org/api/iterator"
 )
 
-const readWritePermission = 0600
+const cacheFilePermissions = 0644
 
 type OutputLocation struct {
 	GCSObjectPath string
@@ -275,7 +275,7 @@ func LoadTestRunResults(ctx *GCSDatastoreContext, runs []base.TestRun) (
 
 	if *cachePath != "" {
 		if _, statErr := os.Stat(*cachePath); os.IsNotExist(statErr) {
-			if err := os.MkdirAll(*cachePath, readWritePermission); err != nil {
+			if err := os.MkdirAll(*cachePath, cacheFilePermissions); err != nil {
 				log.Fatalf("Failed to create cache dir %s: %s", *cachePath, err.Error())
 			}
 		}
@@ -474,13 +474,13 @@ func writeCacheFile(filename string, data []byte) error {
 	func() {
 		pieces := strings.Split(filename, "/")
 		parentDir := strings.Join(pieces[:len(pieces)-1], "/")
-		if err := os.MkdirAll(parentDir, readWritePermission); err != nil {
+		if err := os.MkdirAll(parentDir, cacheFilePermissions); err != nil {
 			log.Printf("Failed to make parent dir %s", parentDir)
 		}
 	}()
 
 	// Write cache file.
-	return ioutil.WriteFile(filename, data, readWritePermission)
+	return ioutil.WriteFile(filename, data, cacheFilePermissions)
 }
 
 func fetchFile(objName string, ctx *GCSDatastoreContext) ([]byte, error) {


### PR DESCRIPTION
## Description
Caches fetched test results file shards under `[--cache_path]/[SHA:10]/[test path]`

Helps with https://github.com/web-platform-tests/results-collection/issues/454, as the server throttles us and eventually demands authentication (throwing a 401) and this kills the Go program, forcing us to start again.

## Review Information
`go run metrics/run/collect_metrics.go --cache_path=foo`