### PR TITLE
Separate steps in Travis config to capture bad status codes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,13 @@ services:
 
 before_install: ./docker_build.sh && ./docker_start.sh
 
-install: |
-  source ./docker_env.sh
-  docker exec -t -u "$(id -u ${USER}):$(id -g ${USER})" "${INSTANCE_NAME}" make build
+install:
+- source ./docker_env.sh
+- docker exec -t -u "$(id -u ${USER}):$(id -g ${USER})" "${INSTANCE_NAME}" make build
 
-script: |
-  source ./docker_env.sh
-  docker exec -t -u "$(id -u ${USER}):$(id -g ${USER})" "${INSTANCE_NAME}" make test
-  docker exec -t -u "$(id -u ${USER}):$(id -g ${USER})" "${INSTANCE_NAME}" make lint
+script:
+- source ./docker_env.sh
+- docker exec -t -u "$(id -u ${USER}):$(id -g ${USER})" "${INSTANCE_NAME}" make test
+- docker exec -t -u "$(id -u ${USER}):$(id -g ${USER})" "${INSTANCE_NAME}" make lint
 
 after_script: ./docker_stop.sh


### PR DESCRIPTION
## Description

Fixes #23 by turning YAML config for build steps into array, rather than multi-line string. Efficacy demonstrated [here](https://travis-ci.org/web-platform-tests/results-analysis/builds/373574343?utm_source=github_status&utm_medium=notification).
