### PR TITLE
Create TestRunLegacy type which drops labels

### DIFF
--- a/metrics/compute/compute.go
+++ b/metrics/compute/compute.go
@@ -9,10 +9,9 @@ import (
 	"strings"
 
 	"github.com/web-platform-tests/results-analysis/metrics"
-	base "github.com/web-platform-tests/wpt.fyi/shared"
 )
 
-type TestRunsStatus map[metrics.TestID]map[base.TestRun]metrics.CompleteTestStatus
+type TestRunsStatus map[metrics.TestID]map[metrics.TestRunLegacy]metrics.CompleteTestStatus
 
 // Type for decision problem: "What does it mean for a test result to 'pass'"?
 type Passes func(*metrics.CompleteTestStatus) bool
@@ -49,7 +48,7 @@ func GatherResultsById(allResults *[]metrics.TestRunResults) (
 		_, ok := resultsById[TestID]
 		if !ok {
 			resultsById[TestID] = make(
-				map[base.TestRun]metrics.CompleteTestStatus)
+				map[metrics.TestRunLegacy]metrics.CompleteTestStatus)
 
 		}
 		_, ok = resultsById[TestID][run]
@@ -70,7 +69,7 @@ func GatherResultsById(allResults *[]metrics.TestRunResults) (
 			_, ok := resultsById[TestID]
 			if !ok {
 				resultsById[TestID] = make(
-					map[base.TestRun]metrics.CompleteTestStatus)
+					map[metrics.TestRunLegacy]metrics.CompleteTestStatus)
 			}
 			_, ok = resultsById[TestID][run]
 			if ok {

--- a/metrics/compute/compute_test.go
+++ b/metrics/compute/compute_test.go
@@ -16,7 +16,7 @@ import (
 
 var timeA = time.Unix(0, 0)
 var timeB = time.Unix(0, 1)
-var runA = shared.TestRun{
+var runA = metrics.TestRunLegacy{
 	ProductAtRevision: shared.ProductAtRevision{
 		Product: shared.Product{
 			BrowserName:    "ABrowser",
@@ -29,7 +29,7 @@ var runA = shared.TestRun{
 	ResultsURL: "http://example.com/a_run.json",
 	CreatedAt:  timeA,
 }
-var runB = shared.TestRun{
+var runB = metrics.TestRunLegacy{
 	ProductAtRevision: shared.ProductAtRevision{
 		Product: shared.Product{
 			BrowserName:    "BBrowser",
@@ -225,12 +225,12 @@ func getPrecomputedStatusz() *TestRunsStatus {
 	ac1x := metrics.TestID{"a/c/1", "x"}
 	ac1y := metrics.TestID{"a/c/1", "y"}
 	ac1z := metrics.TestID{"a/c/1", "z"}
-	statusz[ab1] = make(map[shared.TestRun]metrics.CompleteTestStatus)
-	statusz[ab2] = make(map[shared.TestRun]metrics.CompleteTestStatus)
-	statusz[ac1] = make(map[shared.TestRun]metrics.CompleteTestStatus)
-	statusz[ac1x] = make(map[shared.TestRun]metrics.CompleteTestStatus)
-	statusz[ac1y] = make(map[shared.TestRun]metrics.CompleteTestStatus)
-	statusz[ac1z] = make(map[shared.TestRun]metrics.CompleteTestStatus)
+	statusz[ab1] = make(map[metrics.TestRunLegacy]metrics.CompleteTestStatus)
+	statusz[ab2] = make(map[metrics.TestRunLegacy]metrics.CompleteTestStatus)
+	statusz[ac1] = make(map[metrics.TestRunLegacy]metrics.CompleteTestStatus)
+	statusz[ac1x] = make(map[metrics.TestRunLegacy]metrics.CompleteTestStatus)
+	statusz[ac1y] = make(map[metrics.TestRunLegacy]metrics.CompleteTestStatus)
+	statusz[ac1z] = make(map[metrics.TestRunLegacy]metrics.CompleteTestStatus)
 	statusz[ab1][runA] = status1
 	statusz[ab1][runB] = status2
 	statusz[ab2][runB] = status3

--- a/metrics/models.go
+++ b/metrics/models.go
@@ -219,6 +219,8 @@ type TestRunsMetadata struct {
 	DataURL    string            `json:"url"`
 }
 
+// TODO(lukebjerring): Remove TestRunLegacy when old format migrated.
+
 // TestRunLegacy is a copy of the TestRun struct, before the `Labels` field
 // was added (which causes an array of array and breaks datastore).
 type TestRunLegacy struct {
@@ -236,6 +238,18 @@ type TestRunLegacy struct {
 	// wpt report tool.
 	RawResultsURL string `json:"raw_results_url"`
 }
+
+// ConvertRuns converts TestRuns into the legacy format.
+func ConvertRuns(runs shared.TestRuns) (converted []TestRunLegacy, err error) {
+	if serialized, err := json.Marshal(runs); err != nil {
+		return nil, err
+	} else if err = json.Unmarshal(serialized, &runs); err != nil {
+		return nil, err
+	}
+	return converted, nil
+}
+
+// TODO(lukebjerring): Remove TestRunsMetadataLegacy when old format migrated.
 
 // TestRunsMetadataLegacy is a struct for loading legacy TestRunMetadata entities,
 // which may have nested TestRun entities.
@@ -260,12 +274,9 @@ func (metadata *TestRunsMetadataLegacy) LoadTestRuns(ctx context.Context) (err e
 		if err != nil {
 			return err
 		}
-		// Serialize + unserialize - aka "Copy fields"
-		serialized, err := json.Marshal(newRuns)
-		if err != nil {
+		if metadata.TestRuns, err = ConvertRuns(newRuns); err != nil {
 			return err
 		}
-		err = json.Unmarshal(serialized, &metadata.TestRuns)
 	}
 	return err
 }
@@ -277,6 +288,8 @@ func (metadata *TestRunsMetadataLegacy) LoadTestRuns(ctx context.Context) (err e
 type PassRateMetadata struct {
 	TestRunsMetadata
 }
+
+// TODO(lukebjerring): Remove PassRateMetadataLegacy when old format migrated.
 
 // PassRateMetadataLegacy is a struct for storing a PassRateMetadata entry in the
 // datastore, avoiding nested arrays. PassRateMetadata is the legacy format, used for
@@ -294,6 +307,8 @@ type FailuresMetadata struct {
 	TestRunsMetadata
 	BrowserName string `json:"browser_name"`
 }
+
+// TODO(lukebjerring): Remove FailuresMetadataLegacy when old format migrated.
 
 // FailuresMetadataLegacy is a struct for storing a FailuresMetadata entry in the
 // datastore, avoiding nested arrays. FailuresMetadata is the legacy format, used for

--- a/metrics/models.go
+++ b/metrics/models.go
@@ -6,6 +6,7 @@ package metrics
 
 import (
 	"context"
+	"encoding/json"
 	"time"
 
 	"github.com/web-platform-tests/wpt.fyi/shared"
@@ -13,7 +14,7 @@ import (
 
 // ByCreatedDate sorts tests by run's CreatedAt date (descending)
 // then by platform alphabetically (ascending).
-type ByCreatedDate []shared.TestRun
+type ByCreatedDate []TestRunLegacy
 
 func (s ByCreatedDate) Len() int          { return len(s) }
 func (s ByCreatedDate) Swap(i int, j int) { s[i], s[j] = s[j], s[i] }
@@ -55,7 +56,7 @@ type TestResultsReport struct {
 
 // TestRunResults binds a shared.TestRun to a TestResults.
 type TestRunResults struct {
-	Run *shared.TestRun
+	Run *TestRunLegacy
 	Res *TestResults
 }
 
@@ -218,10 +219,28 @@ type TestRunsMetadata struct {
 	DataURL    string            `json:"url"`
 }
 
+// TestRunLegacy is a copy of the TestRun struct, before the `Labels` field
+// was added (which causes an array of array and breaks datastore).
+type TestRunLegacy struct {
+	ID int64 `json:"id" datastore:"-"`
+
+	shared.ProductAtRevision
+
+	// URL for summary of results, which is derived from raw results.
+	ResultsURL string `json:"results_url"`
+
+	// Time when the test run metadata was first created.
+	CreatedAt time.Time `json:"created_at"`
+
+	// URL for raw results JSON object. Resembles the JSON output of the
+	// wpt report tool.
+	RawResultsURL string `json:"raw_results_url"`
+}
+
 // TestRunsMetadataLegacy is a struct for loading legacy TestRunMetadata entities,
 // which may have nested TestRun entities.
 type TestRunsMetadataLegacy struct {
-	TestRuns   shared.TestRuns   `json:"test_runs"`
+	TestRuns   []TestRunLegacy   `json:"test_runs"`
 	TestRunIDs shared.TestRunIDs `json:"-"`
 	StartTime  time.Time         `json:"start_time"`
 	EndTime    time.Time         `json:"end_time"`
@@ -237,7 +256,16 @@ func (metadata *TestRunsMetadata) LoadTestRuns(ctx context.Context) (err error) 
 // LoadTestRuns fetches the TestRun entities for the PassRateMetadata's TestRunIDs.
 func (metadata *TestRunsMetadataLegacy) LoadTestRuns(ctx context.Context) (err error) {
 	if len(metadata.TestRuns) == 0 {
-		metadata.TestRuns, err = metadata.TestRunIDs.LoadTestRuns(ctx)
+		newRuns, err := metadata.TestRunIDs.LoadTestRuns(ctx)
+		if err != nil {
+			return err
+		}
+		// Serialize + unserialize - aka "Copy fields"
+		serialized, err := json.Marshal(newRuns)
+		if err != nil {
+			return err
+		}
+		err = json.Unmarshal(serialized, &metadata.TestRuns)
 	}
 	return err
 }
@@ -255,8 +283,6 @@ type PassRateMetadata struct {
 // loading the entity, for backward compatibility.
 type PassRateMetadataLegacy struct {
 	TestRunsMetadataLegacy
-	// Override the TestRuns to be omitted by datastore.
-	TestRuns shared.TestRuns `json:"test_runs,omitempty" datastore:"-"`
 }
 
 // FailuresMetadata constitutes metadata capturing:
@@ -274,8 +300,7 @@ type FailuresMetadata struct {
 // loading the entity, for backward compatibility.
 type FailuresMetadataLegacy struct {
 	TestRunsMetadataLegacy
-	// Override the TestRuns to be omitted by datastore.
-	TestRuns shared.TestRuns `json:"test_runs,omitempty" datastore:"-"`
+	BrowserName string `json:"browser_name"`
 }
 
 // RunData is the output type for metrics: Include runs as metadata, and

--- a/metrics/models_test.go
+++ b/metrics/models_test.go
@@ -19,7 +19,7 @@ var today = time.Date(2018, 1, 4, 0, 0, 0, 0, time.UTC)
 var tomorrow = time.Date(2018, 1, 5, 0, 0, 0, 0, time.UTC)
 
 func TestByCreatedDate_DifferentRevisions(t *testing.T) {
-	tests := []models.TestRun{
+	tests := []TestRunLegacy{
 		{
 			ProductAtRevision: models.ProductAtRevision{
 				Product: models.Product{
@@ -44,7 +44,7 @@ func TestByCreatedDate_DifferentRevisions(t *testing.T) {
 }
 
 func TestByCreatedDate_SameRevisions(t *testing.T) {
-	tests := []models.TestRun{
+	tests := []TestRunLegacy{
 		{
 			ProductAtRevision: models.ProductAtRevision{
 				Product: models.Product{

--- a/metrics/run/collect_metrics.go
+++ b/metrics/run/collect_metrics.go
@@ -5,7 +5,6 @@
 package main
 
 import (
-	"encoding/json"
 	"flag"
 	"fmt"
 	"log"
@@ -212,11 +211,9 @@ func main() {
 		*inputGcsBucket)
 
 	readStartTime := time.Now()
-	var runs []metrics.TestRunLegacy
 	runsWithLabels := base.FetchLatestRuns(*wptdHost)
-	if serialized, err := json.Marshal(runsWithLabels); err != nil {
-		log.Fatal(err)
-	} else if err = json.Unmarshal(serialized, &runs); err != nil {
+	runs, err := metrics.ConvertRuns(runsWithLabels)
+	if err != nil {
 		log.Fatal(err)
 	}
 


### PR DESCRIPTION
Turns out we can't save __or load__ with the nested arrays, so this change expands on the backward-compatible data type we are using to drop the label field.

Fixes the https://staging.wpt.fyi/interop/ view.