### PR TITLE
Add RunInfo to TestResultsReport

### DIFF
--- a/metrics/models.go
+++ b/metrics/models.go
@@ -49,9 +49,23 @@ type TestResults struct {
 	Subtests []SubTest `json:"subtests"`
 }
 
+// RunInfo includes some metadata of a test run, and matches the run_info field
+// in the report JSON.
+type RunInfo struct {
+	Revision string `json:"revision"`
+	// The four fields below are very similar to wpt.fyi/shared.Product
+	// except some unfortunate differences (Product vs. BrowserName &
+	// OS vs. OSName).
+	Product        string `json:"product"`
+	BrowserVersion string `json:"browser_version"`
+	OS             string `json:"os"`
+	OSVersion      string `json:"os_version,omitempty"` // optional
+}
+
 // TestResultsReport models the `wpt run` results report JSON file format.
 type TestResultsReport struct {
 	Results []*TestResults `json:"results"`
+	RunInfo RunInfo        `json:"run_info,omitempty"`
 }
 
 // TestRunResults binds a shared.TestRun to a TestResults.

--- a/metrics/models.go
+++ b/metrics/models.go
@@ -49,17 +49,26 @@ type TestResults struct {
 	Subtests []SubTest `json:"subtests"`
 }
 
-// RunInfo includes some metadata of a test run, and matches the run_info field
-// in the report JSON.
+// RunInfo is an alias of ProductAtRevision with a custom marshaler to produce
+// the "run_info" object in wptreport.json.
 type RunInfo struct {
-	Revision string `json:"revision"`
-	// The four fields below are very similar to wpt.fyi/shared.Product
-	// except some unfortunate differences (Product vs. BrowserName &
-	// OS vs. OSName).
-	Product        string `json:"product"`
-	BrowserVersion string `json:"browser_version"`
-	OS             string `json:"os"`
-	OSVersion      string `json:"os_version,omitempty"` // optional
+	shared.ProductAtRevision
+}
+
+// MarshalJSON is the custom JSON marshaler that produces field names matching
+// the "run_info" object in wptreport.json.
+func (r RunInfo) MarshalJSON() ([]byte, error) {
+	m := map[string]string{
+		"revision":        r.FullRevisionHash,
+		"product":         r.BrowserName,
+		"browser_version": r.BrowserVersion,
+		"os":              r.OSName,
+	}
+	// Optional field:
+	if r.OSVersion != "" {
+		m["os_version"] = r.OSVersion
+	}
+	return json.Marshal(m)
 }
 
 // TestResultsReport models the `wpt run` results report JSON file format.


### PR DESCRIPTION
This PR simply adds a `RunInfo` type and a field of that type to `TestResultsReport` so that when unsharding historical runs we can add some metadata from Datastore to the report JSON (https://github.com/web-platform-tests/data-migration/issues/1).

This should not affect results-analysis itself.