### PR TITLE
Make GCS rate limiting optional

### DIFF
--- a/metrics/run/collect_metrics.go
+++ b/metrics/run/collect_metrics.go
@@ -47,6 +47,7 @@ var outputBQFailuresTable *string
 var outputBQFailuresMetadataTable *string
 var pretty *bool
 var gcpCredentialsFile *string
+var rateLimitGCS *bool
 var consolidatedInput *bool
 
 func init() {
@@ -85,6 +86,8 @@ func init() {
 		"Prettify stdout output; appropriate for terminals but not log files")
 	gcpCredentialsFile = flag.String("gcp_credentials_file", "client-secret.json",
 		"Path to Google Cloud Platform file for accessing services")
+	rateLimitGCS = flag.Bool("rate_limit_gcs", true,
+		"Whether or not to rate limit concurrent requests to Google Cloud Storage")
 	consolidatedInput = flag.Bool("consolidated_input", false,
 		"Read input from consolidated results files")
 }
@@ -229,7 +232,11 @@ func main() {
 		log.Fatal(err)
 	}
 
-	allResults, err := inputCtx.LoadTestRunResults(runs, *pretty)
+	var limiter storage.Limiter = nil
+	if *rateLimitGCS {
+		limiter = storage.GCSLimiter()
+	}
+	allResults, err := inputCtx.LoadTestRunResults(runs, limiter, *pretty)
 	readEndTime := time.Now()
 
 	log.Println("Read test results from Google Cloud Storage bucket: " +

--- a/metrics/run/collect_metrics.go
+++ b/metrics/run/collect_metrics.go
@@ -232,7 +232,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	var limiter storage.Limiter = nil
+	var limiter storage.Limiter
 	if *rateLimitGCS {
 		limiter = storage.GCSLimiter()
 	}

--- a/metrics/storage/storage.go
+++ b/metrics/storage/storage.go
@@ -32,6 +32,7 @@ var (
 	limiter = rate.NewLimiter(50, 50)
 )
 
+// Limiter is a simpler subset of rate.Limiter capabilities.
 type Limiter interface {
 	Wait(context.Context) error
 }

--- a/metrics/storage/storage.go
+++ b/metrics/storage/storage.go
@@ -33,17 +33,11 @@ var (
 )
 
 type Limiter interface {
-	Wait(context.Context)
-}
-
-type limiterStruct rate.Limiter
-
-func (l *limiterStruct) Wait(ctx context.Context) {
-	l.Wait(ctx)
+	Wait(context.Context) error
 }
 
 func GCSLimiter() Limiter {
-	return (*limiterStruct)(limiter)
+	return limiter
 }
 
 type OutputLocation struct {

--- a/metrics/storage/storage.go
+++ b/metrics/storage/storage.go
@@ -64,7 +64,7 @@ type Outputter interface {
 type Loader interface {
 	// LoadTestRunResults loads (test run, test results) pairs for given test
 	// runs. Uses client in context to load data from bucket.
-	LoadTestRunResults(runs []metrics.TestRunLegacy, pretty bool) (
+	LoadTestRunResults(runs []metrics.TestRunLegacy, limiter Limiter, pretty bool) (
 		[]metrics.TestRunResults, error)
 }
 


### PR DESCRIPTION
/CC @Hexcles 

This allows scripts/code using https://github.com/web-platform-tests/data-migration to decide whether or not to use rate limiting.