### PR TITLE
Setup matrix of "normal"- and "cron"-type Travis jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,51 @@
 services:
   - docker
 
-before_install: ./docker_build.sh && ./docker_start.sh
+matrix:
+  include:
+    # "Normal" job: Use default metrics parameters.
+    - if: type != cron
+      env:
+      - PROJECT_ID="wptdashboard-staging"
+      - WPTD_HOST="staging.wpt.fyi"
+      - LABELS=""
+    # Cron jobs: Run matrix of metrics data collection runs:
+    # {staging, prod} x {<no-labels>, experimental, stable}
+    - if: type = cron
+      env:
+      - PROJECT_ID="wptdashboard"
+      - WPTD_HOST="wpt.fyi"
+      - LABELS=""
+    - if: type = cron
+      env:
+        - PROJECT_ID="wptdashboard"
+        - WPTD_HOST="wpt.fyi"
+        - LABELS="experimental"
+    - if: type = cron
+      env:
+        - PROJECT_ID="wptdashboard"
+        - WPTD_HOST="wpt.fyi"
+        - LABELS="stable"
+    - if: type = cron
+      env:
+      - PROJECT_ID="wptdashboard-staging"
+      - WPTD_HOST="staging.wpt.fyi"
+      - LABELS=""
+    - if: type = cron
+      env:
+        - PROJECT_ID="wptdashboard-staging"
+        - WPTD_HOST="staging.wpt.fyi"
+        - LABELS="experimental"
+    - if: type = cron
+      env:
+        - PROJECT_ID="wptdashboard-staging"
+        - WPTD_HOST="staging.wpt.fyi"
+        - LABELS="stable"
+
+before_install:
+# Encrypted credentials only needed by cron jobs.
+- if [[ "${TRAVIS_EVENT_TYPE}" == "cron" ]]; then openssl aes-256-cbc -K $encrypted_e5281058aa9e_key -iv $encrypted_e5281058aa9e_iv -in client-secret.json.enc -out client-secret.json -d; fi
+- ./docker_build.sh && ./docker_start.sh
 
 install:
 - source ./docker_env.sh
@@ -13,7 +57,10 @@ install:
 
 script:
 - source ./docker_env.sh
-- docker exec -t -u "$(id -u ${USER}):$(id -g ${USER})" "${INSTANCE_NAME}" make test
-- docker exec -t -u "$(id -u ${USER}):$(id -g ${USER})" "${INSTANCE_NAME}" make lint
+# Non-cron: Run test and lint.
+- if [[ "${TRAVIS_EVENT_TYPE}" != "cron" ]]; then docker exec -t -u "$(id -u ${USER}):$(id -g ${USER})" "${INSTANCE_NAME}" make test; fi
+- if [[ "${TRAVIS_EVENT_TYPE}" != "cron" ]]; then docker exec -t -u "$(id -u ${USER}):$(id -g ${USER})" "${INSTANCE_NAME}" make lint; fi
+# Cron: Run metrics data collection using environment variables.
+- if [[ "${TRAVIS_EVENT_TYPE}" == "cron" ]]; then docker exec -t -u "$(id -u ${USER}):$(id -g ${USER})" "${INSTANCE_NAME}" go run metrics/run/collect_metrics.go -rate_limit_gcs=false -consolidated_input -labels="${LABELS}" -wptd_host="${WPTD_HOST}" -project_id="${PROJECT_ID}"; fi
 
 after_script: ./docker_stop.sh


### PR DESCRIPTION
# Pull Request Template

Update Travis setup to support two classes of runs:

1. "Normal" runs: These should behave the same as before this PR was introduced;
2. "Cron" runs: These should constitute a whole matrix of runs for `{staging, prod} x {<no labels>, experimental, stable}` configurations of metrics computation.

Once this is in place we can create a daily cron job against the master branch to compute metrics.