### PR TITLE
Abstract metrics run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,6 @@ RUN mkdir -p "${WPT_PATH}"
 ENV GOCACHE="/go/.cache"
 
 RUN apk update
-RUN apk add bash git make
+RUN apk add bash build-base git make
 
 WORKDIR "${GO_REPO_PATH}"

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ GO_FILES := $(wildcard $(REPO_PATH)/**/*.go)
 build: deps
 
 collect_metrics: deps var-PROJECT_ID var-INPUT_GCS_BUCKET var-OUTPUT_GCS_BUCKET var-WPTD_HOST
-	cd $(REPO_PATH); go run metrics/run/collect_metrics.go -rate_limit_gcs=false -consolidated_input -project_id="$(PROJECT_ID)" -input_gcs_bucket="$(INPUT_GCS_BUCKET)" -output_gcs_bucket="$(OUTPUT_GCS_BUCKET)" -wptd_host="$(WPTD_HOST)" -labels="$(LABELS)" || cat current_metrics.log
+	cd $(REPO_PATH); go run metrics/run/collect_metrics.go -project_id="$(PROJECT_ID)" -input_gcs_bucket="$(INPUT_GCS_BUCKET)" -output_gcs_bucket="$(OUTPUT_GCS_BUCKET)" -wptd_host="$(WPTD_HOST)" -labels="$(LABELS)" || cat current_metrics.log
 
 lint: deps
 	go get -u golang.org/x/lint/golint

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ GO_FILES := $(wildcard $(REPO_PATH)/**/*.go)
 build: deps
 
 collect_metrics: deps var-PROJECT_ID var-INPUT_GCS_BUCKET var-OUTPUT_GCS_BUCKET var-WPTD_HOST
-	cd $(REPO_PATH); go run metrics/run/collect_metrics.go -project_id="$(PROJECT_ID)" -input_gcs_bucket="$(INPUT_GCS_BUCKET)" -output_gcs_bucket="$(OUTPUT_GCS_BUCKET)" -wptd_host="$(WPTD_HOST)" -labels="$(LABELS)" || cat current_metrics.log
+	cd $(REPO_PATH); go run metrics/run/collect_metrics.go --project_id="$(PROJECT_ID)" --input_gcs_bucket="$(INPUT_GCS_BUCKET)" --output_gcs_bucket="$(OUTPUT_GCS_BUCKET)" --wptd_host="$(WPTD_HOST)" --labels="$(LABELS)"
 
 lint: deps
 	go get -u golang.org/x/lint/golint

--- a/metrics/compute/compute.go
+++ b/metrics/compute/compute.go
@@ -5,10 +5,11 @@
 package compute
 
 import (
-	"log"
+	"context"
 	"strings"
 
 	"github.com/web-platform-tests/results-analysis/metrics"
+	"github.com/web-platform-tests/wpt.fyi/shared"
 )
 
 type TestRunsStatus map[metrics.TestID]map[string]metrics.CompleteTestStatus
@@ -37,8 +38,9 @@ func OkOrPassesAndUnknownOrPasses(status *metrics.CompleteTestStatus) bool {
 
 // Gather results from test runs into input format for Compute* functions in
 // this module.
-func GatherResultsById(allResults *[]metrics.TestRunResults) (
+func GatherResultsById(ctx context.Context, allResults *[]metrics.TestRunResults) (
 	resultsById TestRunsStatus) {
+	logger := ctx.Value(shared.DefaultLoggerCtxKey()).(shared.Logger)
 	resultsById = make(TestRunsStatus)
 
 	for _, results := range *allResults {
@@ -52,7 +54,7 @@ func GatherResultsById(allResults *[]metrics.TestRunResults) (
 		}
 		_, ok = resultsById[TestID][run.BrowserName]
 		if ok {
-			log.Printf("Duplicate results for TestID:%v  in "+
+			logger.Warningf("Duplicate results for TestID:%v  in "+
 				"TestRun:%v.  Overwriting.\n", TestID, run)
 		}
 		newStatus := metrics.CompleteTestStatus{
@@ -71,7 +73,7 @@ func GatherResultsById(allResults *[]metrics.TestRunResults) (
 			}
 			_, ok = resultsById[TestID][run.BrowserName]
 			if ok {
-				log.Printf("Duplicate sub-results for "+
+				logger.Warningf("Duplicate sub-results for "+
 					"TestID:%v  in TestRun:%v.  "+
 					"Overwriting.\n", TestID, run)
 			}

--- a/metrics/compute/compute.go
+++ b/metrics/compute/compute.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/web-platform-tests/results-analysis/metrics"
-	"github.com/web-platform-tests/wpt.fyi/shared"
 )
 
 type TestRunsStatus map[metrics.TestID]map[string]metrics.CompleteTestStatus
@@ -40,7 +39,7 @@ func OkOrPassesAndUnknownOrPasses(status *metrics.CompleteTestStatus) bool {
 // this module.
 func GatherResultsById(ctx context.Context, allResults *[]metrics.TestRunResults) (
 	resultsById TestRunsStatus) {
-	logger := ctx.Value(shared.DefaultLoggerCtxKey()).(shared.Logger)
+	logger := metrics.GetLogger(ctx)
 	resultsById = make(TestRunsStatus)
 
 	for _, results := range *allResults {

--- a/metrics/compute/compute_test.go
+++ b/metrics/compute/compute_test.go
@@ -65,7 +65,8 @@ func TestGatherResultsById_TwoRuns_SameTest(t *testing.T) {
 			},
 		},
 	}
-	gathered := GatherResultsById(results)
+
+	gathered := GatherResultsById(shared.NewTestContext(), results)
 	assert.Equal(t, 1, len(gathered)) // Merged to single TestId: {"A test",""}.
 	for testID, runStatusMap := range gathered {
 		assert.Equal(t, metrics.TestID{"A test", ""}, testID)
@@ -121,7 +122,7 @@ func TestGatherResultsById_TwoRuns_DiffTests(t *testing.T) {
 			},
 		},
 	}
-	gathered := GatherResultsById(results)
+	gathered := GatherResultsById(shared.NewTestContext(), results)
 	assert.Equal(t, 3, len(gathered)) // A, Shared, B.
 	assert.Equal(t, 1, len(gathered[metrics.TestID{"A test", ""}]))
 	assert.Equal(t, metrics.CompleteTestStatus{
@@ -172,7 +173,7 @@ func TestGatherResultsById_OneRun_SubTest(t *testing.T) {
 			},
 		},
 	}
-	gathered := GatherResultsById(results)
+	gathered := GatherResultsById(shared.NewTestContext(), results)
 	assert.Equal(t, 3, len(gathered)) // Top-level test + 2 sub-tests.
 	testIds := make([]metrics.TestID, 0, len(gathered))
 	for testId, _ := range gathered {

--- a/metrics/logging.go
+++ b/metrics/logging.go
@@ -1,0 +1,24 @@
+// Copyright 2018 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package metrics
+
+import (
+	"context"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/web-platform-tests/wpt.fyi/shared"
+)
+
+// GetLogger retrieves a non-nil shared.Logger that is appropriate for use in
+// ctx. If ctx does not provide a logger, then a nil-logger is returned.
+func GetLogger(ctx context.Context) shared.Logger {
+	logger, ok := ctx.Value(shared.DefaultLoggerCtxKey()).(shared.Logger)
+	if !ok || logger == nil {
+		log.Warningf("Context without logger: %v; logs will be dropped", ctx)
+		return shared.NewNilLogger()
+	}
+
+	return logger
+}

--- a/metrics/run/api/api.go
+++ b/metrics/run/api/api.go
@@ -117,7 +117,7 @@ func NewMetricsComputerFromArgs(args []string) (MetricsComputer, []string, error
 }
 
 func (mcd *metricsComputerData) Compute(ctx context.Context, shortSHA string, labels []string) error {
-	logger := ctx.Value(shared.DefaultLoggerCtxKey()).(shared.Logger)
+	logger := metrics.GetLogger(ctx)
 
 	var gcsClient *gcs.Client
 	var err error

--- a/metrics/run/api/api.go
+++ b/metrics/run/api/api.go
@@ -59,27 +59,27 @@ type MetricsComputer interface {
 }
 
 type metricsComputerData struct {
-	ProjectID                     string `short:"project_id" default:"wptdashboard-staging" description:"Google Cloud Platform project id"`
-	InputGCSBucket                string `short:"input_gcs_bucket" description:"Google Cloud Storage bucket from which  test results are fetched"`
-	OutputGCSBucket               string `short:"output_gcs_bucket" default:"wptd-metrics-staging" description:"Google Cloud Storage bucket where metrics are stored"`
-	OutputBQMetadataDataset       string `short:"output_bq_metadata_dataset" description:"BigQuery dataset where metrics metadata are stored"`
-	OutputBQDataDataset           string `short:"output_bq_data_dataset" description:"BigQuery dataset where metrics data are stored"`
-	OutputBQPassRateTable         string `short:"output_bq_pass_rate_table" description:"BigQuery table where pass rate metrics are stored"`
-	OutputBQPassRateMetadataTable string `short:"output_bq_pass_rate_metadata_table" description:"BigQuery table where pass rate metrics are stored"`
-	OutputBQFailuresTable         string `short:"output_bq_failures_table" description:"BigQuery table where test failure lists are stored"`
-	OutputBQFailuresMetadataTable string `short:"output_bq_failures_metadata_table" description:"BigQuery table where pass rate metrics are stored"`
-	WPTDHost                      string `short:"wptd_host" default:"staging.wpt.fyi" description:"Hostname of endpoint that serves WPT Dashboard data API"`
-	GCPCredentialsFile            string `short:"gcp_credentials_file" default:"client-secret.json" description:"Path to Google Cloud Platform file for accessing services"`
-	Pretty                        bool   `short:"pretty" description:"Prettify stdout output; appropriate for terminals but not log files"`
-	RateLimitGCS                  bool   `short:"rate_limit_gcs" description:"Whether or not to rate limit concurrent requests to Google Cloud Storage"`
-	ShardedInput                  bool   `short:"sharded_input" description:"Read input from sharded (rather than consolidated) results files"`
+	ProjectID                     string `long:"project_id" default:"wptdashboard-staging" description:"Google Cloud Platform project id"`
+	InputGCSBucket                string `long:"input_gcs_bucket" description:"Google Cloud Storage bucket from which  test results are fetched"`
+	OutputGCSBucket               string `long:"output_gcs_bucket" default:"wptd-metrics-staging" description:"Google Cloud Storage bucket where metrics are stored"`
+	OutputBQMetadataDataset       string `long:"output_bq_metadata_dataset" description:"BigQuery dataset where metrics metadata are stored"`
+	OutputBQDataDataset           string `long:"output_bq_data_dataset" description:"BigQuery dataset where metrics data are stored"`
+	OutputBQPassRateTable         string `long:"output_bq_pass_rate_table" description:"BigQuery table where pass rate metrics are stored"`
+	OutputBQPassRateMetadataTable string `long:"output_bq_pass_rate_metadata_table" description:"BigQuery table where pass rate metrics are stored"`
+	OutputBQFailuresTable         string `long:"output_bq_failures_table" description:"BigQuery table where test failure lists are stored"`
+	OutputBQFailuresMetadataTable string `long:"output_bq_failures_metadata_table" description:"BigQuery table where pass rate metrics are stored"`
+	WPTDHost                      string `long:"wptd_host" default:"staging.wpt.fyi" description:"Hostname of endpoint that serves WPT Dashboard data API"`
+	GCPCredentialsFile            string `long:"gcp_credentials_file" default:"client-secret.json" description:"Path to Google Cloud Platform file for accessing services"`
+	Pretty                        bool   `long:"pretty" description:"Prettify stdout output; appropriate for terminals but not log files"`
+	RateLimitGCS                  bool   `long:"rate_limit_gcs" description:"Whether or not to rate limit concurrent requests to Google Cloud Storage"`
+	ShardedInput                  bool   `long:"sharded_input" description:"Read input from sharded (rather than consolidated) results files"`
 }
 
 func NewMetricsComputerFromArgs(args []string) (MetricsComputer, []string, error) {
 	unixNow := time.Now().Unix()
 
 	var mcd metricsComputerData
-	rest, err := flags.ParseArgs(&mcd, args)
+	rest, err := flags.NewParser(&mcd, flags.IgnoreUnknown).ParseArgs(args)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -115,7 +115,6 @@ func NewMetricsComputerFromArgs(args []string) (MetricsComputer, []string, error
 }
 
 func (mcd *metricsComputerData) Compute(ctx context.Context, shortSHA string, labels []string) error {
-	// TODO(markdittmer): Write os.File-based shared.Logger implementation.
 	logger := ctx.Value(shared.DefaultLoggerCtxKey()).(shared.Logger)
 
 	var gcsClient *gcs.Client
@@ -178,7 +177,7 @@ func (mcd *metricsComputerData) Compute(ctx context.Context, shortSHA string, la
 
 	logger.Infof("Consolidating results")
 
-	resultsByID := compute.GatherResultsById(&allResults)
+	resultsByID := compute.GatherResultsById(ctx, &allResults)
 
 	logger.Infof("Consolidated results")
 	logger.Infof("Computing metrics")

--- a/metrics/run/api/api.go
+++ b/metrics/run/api/api.go
@@ -28,20 +28,22 @@ var defaultStagingComputer = metricsComputerData{
 	ProjectID:       "wptdashboard-staging",
 	InputGCSBucket:  DefaultConsolidatedInputBucket,
 	OutputGCSBucket: "wptd-metrics-staging",
-	WPTDHost:        "staging.wpt.fyi",
-	Pretty:          false,
-	RateLimitGCS:    false,
-	ShardedInput:    false,
+	// No BQ config: Output to GCS only.
+	WPTDHost:     "staging.wpt.fyi",
+	Pretty:       false,
+	RateLimitGCS: false,
+	ShardedInput: false,
 }
 
 var defaultProdComputer = metricsComputerData{
 	ProjectID:       "wptdashboard",
 	InputGCSBucket:  DefaultConsolidatedInputBucket,
 	OutputGCSBucket: "wptd-metrics",
-	WPTDHost:        "wpt.fyi",
-	Pretty:          false,
-	RateLimitGCS:    false,
-	ShardedInput:    false,
+	// No BQ config: Output to GCS only.
+	WPTDHost:     "wpt.fyi",
+	Pretty:       false,
+	RateLimitGCS: false,
+	ShardedInput: false,
 }
 
 var DefaultStagingComputer = func() MetricsComputer {

--- a/metrics/run/collect_metrics.go
+++ b/metrics/run/collect_metrics.go
@@ -6,16 +6,18 @@ package main
 
 import (
 	"os"
+	"strings"
 
 	flags "github.com/jessevdk/go-flags"
 	log "github.com/sirupsen/logrus"
 	"github.com/web-platform-tests/results-analysis/metrics/run/api"
+	"github.com/web-platform-tests/wpt.fyi/shared"
 	"golang.org/x/net/context"
 )
 
 type labelsAndShortSHA struct {
-	labels   []string `short:"label" description:"Labels to filter by when computing interop"`
-	shortSHA string   `short:"sha" description:"SHA[0:10] of the runs to use when computing interop"`
+	Labels   []string `long:"labels" description:"Labels to filter by when computing interop"`
+	ShortSHA string   `long:"sha" description:"SHA[0:10] of the runs to use when computing interop"`
 }
 
 func main() {
@@ -33,22 +35,46 @@ func main() {
 		log.Fatalf("Not all arguments parsed; unparsed arguments: %v", rest)
 	}
 
-	/*
-		// TODO(markdittmer): Re-introduce file-based logging.
-
-		logFileName := "current_metrics.log"
-		logFile, err := os.OpenFile(logFileName, os.O_RDWR|os.O_CREATE|
-			os.O_APPEND, 0666)
-		if err != nil {
-			log.Fatalf("Error opening log file: %v", err)
+	labels := make([]string, 0, len(lass.Labels)+1)
+	for _, label := range lass.Labels {
+		splitLabels := strings.Split(label, ",")
+		for _, lbl := range splitLabels {
+			if lbl != "" {
+				labels = append(labels, lbl)
+			}
 		}
-		defer logFile.Close()
-		log.Printf("Logs appended to %s\n", logFileName)
-		log.SetOutput(logFile)
-	*/
+	}
+	lass.Labels = labels
 
-	ctx := context.Background()
-	err = metricsAPI.Compute(ctx, lass.shortSHA, lass.labels)
+	var ctx context.Context
+	stdoutLogger := &log.Logger{
+		Out:       os.Stderr,
+		Formatter: new(log.TextFormatter),
+		Hooks:     make(log.LevelHooks),
+		Level:     log.WarnLevel,
+	}
+	logFileName := "current_metrics.log"
+	logFile, err := os.OpenFile(logFileName, os.O_RDWR|os.O_CREATE|
+		os.O_APPEND, 0666)
+	if err != nil {
+		log.Warningf("Failed to setup file-based logging: %v", err)
+		ctx = context.WithValue(context.Background(), shared.DefaultLoggerCtxKey(), stdoutLogger)
+	} else {
+		defer logFile.Close()
+		log.Printf("Detailed logs appended to %s\n", logFileName)
+
+		ctx = context.WithValue(context.Background(), shared.DefaultLoggerCtxKey(), shared.SplitLogger{
+			A: stdoutLogger,
+			B: &log.Logger{
+				Out:       logFile,
+				Formatter: new(log.TextFormatter),
+				Hooks:     make(log.LevelHooks),
+				Level:     log.DebugLevel,
+			},
+		})
+	}
+
+	err = metricsAPI.Compute(ctx, lass.ShortSHA, lass.Labels)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/metrics/run/collect_metrics.go
+++ b/metrics/run/collect_metrics.go
@@ -63,15 +63,17 @@ func main() {
 		defer logFile.Close()
 		log.Printf("Detailed logs appended to %s\n", logFileName)
 
-		ctx = context.WithValue(context.Background(), shared.DefaultLoggerCtxKey(), shared.SplitLogger{
-			A: stdoutLogger,
-			B: &log.Logger{
-				Out:       logFile,
-				Formatter: new(log.TextFormatter),
-				Hooks:     make(log.LevelHooks),
-				Level:     log.DebugLevel,
-			},
-		})
+		ctx = context.WithValue(context.Background(), shared.DefaultLoggerCtxKey(),
+			shared.NewLoggerMux([]shared.Logger{
+				stdoutLogger,
+				&log.Logger{
+					Out:       logFile,
+					Formatter: new(log.TextFormatter),
+					Hooks:     make(log.LevelHooks),
+					Level:     log.DebugLevel,
+				},
+			}),
+		)
 	}
 
 	err = metricsAPI.Compute(ctx, lass.ShortSHA, lass.Labels)

--- a/metrics/run/collect_metrics.go
+++ b/metrics/run/collect_metrics.go
@@ -5,483 +5,51 @@
 package main
 
 import (
-	"flag"
-	"fmt"
-	"log"
 	"os"
-	"sort"
-	"strings"
-	"sync"
-	"time"
 
-	"github.com/deckarep/golang-set"
-
-	"google.golang.org/api/option"
-
-	"cloud.google.com/go/bigquery"
-	"cloud.google.com/go/datastore"
-	gcs "cloud.google.com/go/storage"
-	"github.com/web-platform-tests/results-analysis/metrics"
-	"github.com/web-platform-tests/results-analysis/metrics/compute"
-	"github.com/web-platform-tests/results-analysis/metrics/storage"
-	base "github.com/web-platform-tests/wpt.fyi/shared"
+	flags "github.com/jessevdk/go-flags"
+	log "github.com/sirupsen/logrus"
+	"github.com/web-platform-tests/results-analysis/metrics/run/api"
 	"golang.org/x/net/context"
 )
 
-const (
-	DEFAULT_SHARDED_INPUT_BUCKET      = "wptd"
-	DEFAULT_CONSOLIDATED_INPUT_BUCKET = "wptd-results"
-)
-
-var wptDataPath *string
-var projectId *string
-var inputGcsBucket *string
-var outputGcsBucket *string
-var wptdHost *string
-var labels *string
-var sha *string
-var outputBQMetadataDataset *string
-var outputBQDataDataset *string
-var outputBQPassRateTable *string
-var outputBQPassRateMetadataTable *string
-var outputBQFailuresTable *string
-var outputBQFailuresMetadataTable *string
-var pretty *bool
-var gcpCredentialsFile *string
-var rateLimitGCS *bool
-var consolidatedInput *bool
-
-func init() {
-	unixNow := time.Now().Unix()
-	wptDataPath = flag.String("wpt_data_path", os.Getenv("HOME")+
-		"/wpt-data", "Path to data directory for local data copied "+
-		"from Google Cloud Storage")
-	projectId = flag.String("project_id", "wptdashboard-staging",
-		"Google Cloud Platform project id")
-	inputGcsBucket = flag.String("input_gcs_bucket", DEFAULT_SHARDED_INPUT_BUCKET,
-		"Google Cloud Storage bucket where test results are stored")
-	outputGcsBucket = flag.String("output_gcs_bucket", "wptd-metrics-staging",
-		"Google Cloud Storage bucket where metrics are stored")
-	outputBQMetadataDataset = flag.String("output_bq_metadata_dataset",
-		fmt.Sprintf("wptd_metrics_%d", unixNow),
-		"BigQuery dataset where metrics metadata are stored")
-	outputBQDataDataset = flag.String("output_bq_data_dataset",
-		fmt.Sprintf("wptd_metrics_%d", unixNow),
-		"BigQuery dataset where metrics data are stored")
-	outputBQPassRateTable = flag.String("output_bq_pass_rate_table",
-		fmt.Sprintf("PassRates_%d", unixNow),
-		"BigQuery table where pass rate metrics are stored")
-	outputBQPassRateMetadataTable = flag.String("output_bq_pass_rate_metadata_table",
-		fmt.Sprintf("PassRateMetadata_%d", unixNow),
-		"BigQuery table where pass rate metrics are stored")
-	outputBQFailuresTable = flag.String("output_bq_failures_table",
-		fmt.Sprintf("Failures_%d", unixNow),
-		"BigQuery table where test failure lists are stored")
-	outputBQFailuresMetadataTable = flag.String("output_bq_failures_metadata_table",
-		fmt.Sprintf("FailuresMetadata_%d", unixNow),
-		"BigQuery table where pass rate metrics are stored")
-	wptdHost = flag.String("wptd_host", "staging.wpt.fyi",
-		"Hostname of endpoint that serves WPT Dashboard data API")
-	labels = flag.String("labels", "", "Labels to filter by when computing interop")
-	sha = flag.String("sha", "", "SHA[0:10] of the runs to use when computing interop")
-	pretty = flag.Bool("pretty", false,
-		"Prettify stdout output; appropriate for terminals but not log files")
-	gcpCredentialsFile = flag.String("gcp_credentials_file", "client-secret.json",
-		"Path to Google Cloud Platform file for accessing services")
-	rateLimitGCS = flag.Bool("rate_limit_gcs", true,
-		"Whether or not to rate limit concurrent requests to Google Cloud Storage")
-	consolidatedInput = flag.Bool("consolidated_input", false,
-		"Read input from consolidated results files")
+type labelsAndShortSHA struct {
+	labels   []string `short:"label" description:"Labels to filter by when computing interop"`
+	shortSHA string   `short:"sha" description:"SHA[0:10] of the runs to use when computing interop"`
 }
-
-/*
-
-
-Collect metrics from WPT test runs
-
-Runtime environment requirements:
-
-  GCP Application Default Credentials
-    Example of how to setup:
-      $ gcloud config set project wptdashboard
-      $ gcloud auth application-default login
-      # ... follow prompts to authenticate in browser
-
-Inputs:
-  Latest WPT test runs exposed via WPTD endpoint
-
-Outputs:
-  - Compressed JSON files in GCS detailing metrics
-  - BQ tables detailing metrics
-  - Local logs in "current_metrics.log"
-
-Run with:
-
-  make go_deps && cd $GOPATH && go run \
-    src/github.com/web-platform-tests/results-analysis/metrics/run/collect_metrics.go [flags]
-
-To run in development environment:
-
-  make go_deps && cd $(go env GOPATH) && go run metrics/run/collect_metrics.go [flags]
-
-
-Flags:
-
-  wpt_data_path (default: $HOME/wpt-data)
-    Path to data directory for local data copied from Google Cloud Storage
-
-  project_id (default: wptdashboard-staging)
-    Google Cloud Platform project id
-
-  input_gcs_bucket (default: wptd-results)
-    Google Cloud Storage bucket where test results are stored
-
-  output_gcs_bucket (default: wptd-metrics-staging)
-    Google Cloud Storage bucket where metrics are stored
-
-  output_bq_metadata_dataset (default: wptd_metrics_[current UNIX time])
-    BigQuery dataset where metrics metadata are stored
-
-  output_bq_data_dataset (default: wptd_metrics_[current UNIX time])
-    BigQuery dataset where metrics data are stored
-
-  output_bq_pass_rate_table (default: PassRates_[current UNIX time])
-    BigQuery table where pass rate metrics are stored
-
-  output_bq_pass_rate_metadata_table (default: PassRateMetadata_[current UNIX time])
-    BigQuery table where pass rate metrics are stored
-
-  output_bq_failures_table (default: Failures_[current UNIX time])
-    BigQuery table where test failure lists are stored
-
-  output_bq_failures_metadata_table (default: FailuresMetadata_[current UNIX time])
-    BigQuery table where pass rate metrics are stored
-
-  wptd_host (default: staging.wpt.fyi)
-		Hostname of endpoint that serves WPT Dashboard data API
-
-	pretty (default: false)
-		Prettify stdout output; appropriate for terminals but not log files
-	gcpCredentialsFile (default: client-secret.json)
-		Path to Google Cloud Platform file for accessing services
-	consolidatedInput (default: false)
-		Read input from consolidated results files
-
-Data collection procedure:
-  1. Fetch latest runs from WPTD endpoint
-  2. Load each run's results by iterating over files in GCS folder associated
-     with run's results
-  3. Use raw run results as input to two metrics calculations:
-     (a) Per directory/test file: Count of runs passing in [0, 1, ..., n]
-         browsers
-     (b) Per browser: tests failing in this browser and [0, 1, .., n - 1]
-         browsers
-  4. Upload metrics as JSON files to GCS and as tables to BQ
-
-*/
 
 func main() {
-	log.SetFlags(log.LstdFlags | log.Lshortfile)
-
-	flag.Parse()
-	if *consolidatedInput && *inputGcsBucket == DEFAULT_SHARDED_INPUT_BUCKET {
-		log.Printf(
-			"Using consolidated GCS bucket, %s, rather than sharded bucket, %s",
-			DEFAULT_CONSOLIDATED_INPUT_BUCKET, DEFAULT_SHARDED_INPUT_BUCKET)
-		*inputGcsBucket = DEFAULT_CONSOLIDATED_INPUT_BUCKET
-	}
-
-	logFileName := "current_metrics.log"
-	logFile, err := os.OpenFile(logFileName, os.O_RDWR|os.O_CREATE|
-		os.O_APPEND, 0666)
+	metricsAPI, rest, err := api.NewMetricsComputerFromArgs(os.Args[1:])
 	if err != nil {
-		log.Fatalf("Error opening log file: %v", err)
+		log.Fatal(err)
 	}
-	defer logFile.Close()
-	log.Printf("Logs appended to %s\n", logFileName)
-	log.SetOutput(logFile)
+
+	var lass labelsAndShortSHA
+	rest, err = flags.ParseArgs(&lass, rest)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if len(rest) > 0 {
+		log.Fatalf("Not all arguments parsed; unparsed arguments: %v", rest)
+	}
+
+	/*
+		// TODO(markdittmer): Re-introduce file-based logging.
+
+		logFileName := "current_metrics.log"
+		logFile, err := os.OpenFile(logFileName, os.O_RDWR|os.O_CREATE|
+			os.O_APPEND, 0666)
+		if err != nil {
+			log.Fatalf("Error opening log file: %v", err)
+		}
+		defer logFile.Close()
+		log.Printf("Logs appended to %s\n", logFileName)
+		log.SetOutput(logFile)
+	*/
 
 	ctx := context.Background()
-	gcsClient, err := gcs.NewClient(ctx,
-		option.WithCredentialsFile(*gcpCredentialsFile))
+	err = metricsAPI.Compute(ctx, lass.shortSHA, lass.labels)
 	if err != nil {
 		log.Fatal(err)
 	}
-	inputBucket := gcsClient.Bucket(*inputGcsBucket)
-	ctxF := storage.NewShardedGCSDatastoreContext
-	if *consolidatedInput {
-		ctxF = storage.NewConsolidatedGCSDatastoreContext
-	}
-	inputCtx := ctxF(ctx, storage.Bucket{
-		Name:   *inputGcsBucket,
-		Handle: inputBucket,
-	}, nil)
-
-	log.Println("Reading test results from Google Cloud Storage bucket: " +
-		*inputGcsBucket)
-
-	readStartTime := time.Now()
-	var labelSet mapset.Set
-	if *labels != "" {
-		labelSet = mapset.NewSet()
-		for _, label := range strings.Split(*labels, ",") {
-			labelSet.Add(label)
-		}
-	}
-
-	filters := base.TestRunFilter{
-		SHA:    *sha,
-		Labels: labelSet,
-	}
-	runsWithLabels, err := base.FetchRuns(*wptdHost, filters)
-	if err != nil {
-		log.Fatal(err)
-	}
-	runs, err := metrics.ConvertRuns(runsWithLabels)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	var limiter storage.Limiter
-	if *rateLimitGCS {
-		limiter = storage.GCSLimiter()
-	}
-	allResults, err := inputCtx.LoadTestRunResults(runs, limiter, *pretty)
-	readEndTime := time.Now()
-
-	log.Println("Read test results from Google Cloud Storage bucket: " +
-		*inputGcsBucket)
-
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	log.Println("Consolidating results")
-
-	resultsById := compute.GatherResultsById(&allResults)
-
-	log.Println("Consolidated results")
-	log.Println("Computing metrics")
-
-	var totals map[string]int
-	var passRateMetric map[string][]int
-	failuresMetrics := make(map[string][][]metrics.TestID)
-	var wg sync.WaitGroup
-	wg.Add(2 + len(runs))
-	go func() {
-		defer wg.Done()
-		totals = compute.ComputeTotals(&resultsById)
-	}()
-	go func() {
-		defer wg.Done()
-		passRateMetric = compute.ComputePassRateMetric(len(runs),
-			&resultsById, compute.OkOrPassesAndUnknownOrPasses)
-	}()
-	for _, run := range runs {
-		go func(browserName string) {
-			defer wg.Done()
-			// TODO: Check that browser names are different
-			failuresMetrics[browserName] =
-				compute.ComputeBrowserFailureList(len(runs),
-					browserName, &resultsById,
-					compute.OkOrPassesAndUnknownOrPasses)
-		}(run.BrowserName)
-	}
-	wg.Wait()
-
-	log.Println("Computed metrics")
-	log.Println("Uploading metrics")
-
-	outputBucket := gcsClient.Bucket(*outputGcsBucket)
-	datastoreClient, err := datastore.NewClient(ctx, *projectId,
-		option.WithCredentialsFile(*gcpCredentialsFile))
-	if err != nil {
-		log.Fatal(err)
-	}
-	bigqueryClient, err := bigquery.NewClient(ctx, *projectId,
-		option.WithCredentialsFile(*gcpCredentialsFile))
-	if err != nil {
-		log.Fatal(err)
-	}
-	outputters := [2]storage.Outputter{
-		storage.NewShardedGCSDatastoreContext(ctx, storage.Bucket{
-			Name:   *outputGcsBucket,
-			Handle: outputBucket,
-		}, datastoreClient),
-		storage.BQContext{
-			Context: ctx,
-			Client:  bigqueryClient,
-		},
-	}
-
-	gcsDir := fmt.Sprintf("%d-%d", readStartTime.Unix(),
-		readEndTime.Unix())
-	passRatesBasename := "pass-rates"
-	passRateGCSPath := fmt.Sprintf("%s/%s.json.gz", gcsDir,
-		passRatesBasename)
-	passRatesUrl := fmt.Sprintf(
-		"https://storage.googleapis.com/%s/%s",
-		*outputGcsBucket,
-		passRateGCSPath)
-	failuresBasenamef := func(browserName string) string {
-		return fmt.Sprintf("%s-failures", browserName)
-	}
-	failuresGCSPathf := func(browserName string) string {
-		return fmt.Sprintf("%s/%s.json.gz", gcsDir,
-			failuresBasenamef(browserName))
-	}
-	failuresUrlf := func(browserName string) string {
-		return fmt.Sprintf(
-			"https://storage.googleapis.com/%s/%s",
-			*outputGcsBucket,
-			failuresGCSPathf(browserName))
-	}
-	passRateMetadata := metrics.PassRateMetadata{
-		TestRunsMetadata: metrics.TestRunsMetadata{
-			StartTime:  readStartTime,
-			EndTime:    readEndTime,
-			TestRunIDs: runsWithLabels.GetTestRunIDs(),
-			DataURL:    passRatesUrl,
-		},
-	}
-
-	wg.Add((1 + len(failuresMetrics)) * len(outputters))
-	processUploadErrors := func(errs []error) {
-		for _, err := range errs {
-			log.Printf("Upload error: %v", err)
-		}
-		if len(errs) > 0 {
-			log.Fatal(errs[len(errs)-1])
-		}
-	}
-	for _, outputter := range outputters {
-		go func(outputter storage.Outputter) {
-			defer wg.Done()
-			outputId := storage.OutputId{
-				MetadataLocation: storage.OutputLocation{
-					BQDatasetName: *outputBQMetadataDataset,
-					BQTableName:   *outputBQPassRateMetadataTable,
-				},
-				DataLocation: storage.OutputLocation{
-					GCSObjectPath: passRateGCSPath,
-					BQDatasetName: *outputBQDataDataset,
-					BQTableName:   *outputBQPassRateTable,
-				},
-			}
-			_, _, errs := uploadTotalsAndPassRateMetric(
-				&passRateMetadata, outputter, outputId, totals,
-				passRateMetric)
-			processUploadErrors(errs)
-		}(outputter)
-		for browserName, failuresMetric := range failuresMetrics {
-			go func(browserName string, failuresMetric [][]metrics.TestID, outputter storage.Outputter) {
-				defer wg.Done()
-				failuresMetadata := metrics.FailuresMetadata{
-					TestRunsMetadata: metrics.TestRunsMetadata{
-						StartTime:  readStartTime,
-						EndTime:    readEndTime,
-						TestRunIDs: runsWithLabels.GetTestRunIDs(),
-						DataURL:    failuresUrlf(browserName),
-					},
-					BrowserName: browserName,
-				}
-				outputId := storage.OutputId{
-					MetadataLocation: storage.OutputLocation{
-						BQDatasetName: *outputBQMetadataDataset,
-						BQTableName:   *outputBQFailuresMetadataTable,
-					},
-					DataLocation: storage.OutputLocation{
-						GCSObjectPath: gcsDir +
-							"/" +
-							failuresBasenamef(browserName) +
-							".json.gz",
-						BQDatasetName: *outputBQDataDataset,
-						BQTableName:   *outputBQFailuresTable,
-					},
-				}
-				_, _, errs := uploadFailureLists(&failuresMetadata,
-					outputter, outputId, browserName,
-					failuresMetric)
-				processUploadErrors(errs)
-			}(browserName, failuresMetric, outputter)
-		}
-	}
-	wg.Wait()
-
-	log.Printf("Uploaded metrics")
-}
-
-type FailureListsRow struct {
-	BrowserName      string         `json:"browser_name"`
-	NumOtherFailures int            `json:"num_other_failures"`
-	Tests            metrics.TestID `json:"test"`
-}
-type ByTestId []interface{}
-
-func (s ByTestId) Len() int          { return len(s) }
-func (s ByTestId) Swap(i int, j int) { s[i], s[j] = s[j], s[i] }
-func (s ByTestId) Less(i int, j int) bool {
-	return s[i].(FailureListsRow).Tests.Test < s[j].(FailureListsRow).Tests.Test
-}
-
-func failureListsToRows(browserName string, failureLists [][]metrics.TestID) (
-	rows []interface{}) {
-	numRows := 0
-	for _, failureList := range failureLists {
-		numRows += len(failureList)
-	}
-	rows = make([]interface{}, 0, numRows)
-	for i, failuresPtrList := range failureLists {
-		for _, failure := range failuresPtrList {
-			rows = append(rows, FailureListsRow{
-				browserName,
-				i,
-				failure,
-			})
-		}
-	}
-	sort.Sort(ByTestId(rows))
-	return rows
-}
-
-type PassRateMetricRow struct {
-	Dir       string `json:"dir"`
-	PassRates []int  `json:"pass_rates"`
-	Total     int    `json:"total"`
-}
-type ByDir []interface{}
-
-func (s ByDir) Len() int          { return len(s) }
-func (s ByDir) Swap(i int, j int) { s[i], s[j] = s[j], s[i] }
-func (s ByDir) Less(i int, j int) bool {
-	return s[i].(PassRateMetricRow).Dir < s[j].(PassRateMetricRow).Dir
-}
-
-func totalsAndPassRateMetricToRows(totals map[string]int,
-	passRateMetric map[string][]int) (
-	rows []interface{}) {
-
-	rows = make([]interface{}, 0, len(passRateMetric))
-	for dir, passRates := range passRateMetric {
-		rows = append(rows, PassRateMetricRow{dir, passRates,
-			totals[dir]})
-	}
-	sort.Sort(ByDir(rows))
-	return rows
-}
-
-func uploadTotalsAndPassRateMetric(metricsRun *metrics.PassRateMetadata,
-	outputter storage.Outputter, id storage.OutputId,
-	totals map[string]int, passRateMetric map[string][]int) (
-	interface{}, []interface{}, []error) {
-	rows := totalsAndPassRateMetricToRows(totals, passRateMetric)
-	return outputter.Output(id, metricsRun, rows)
-}
-
-func uploadFailureLists(metricsRun *metrics.FailuresMetadata,
-	outputter storage.Outputter, id storage.OutputId,
-	browserName string, failureLists [][]metrics.TestID) (
-	interface{}, []interface{}, []error) {
-	rows := failureListsToRows(browserName, failureLists)
-	return outputter.Output(id, metricsRun, rows)
 }

--- a/metrics/storage/storage.go
+++ b/metrics/storage/storage.go
@@ -22,7 +22,6 @@ import (
 	"cloud.google.com/go/storage"
 	tm "github.com/buger/goterm"
 	"github.com/web-platform-tests/results-analysis/metrics"
-	"github.com/web-platform-tests/wpt.fyi/shared"
 	"golang.org/x/net/context"
 	"golang.org/x/time/rate"
 	"google.golang.org/api/iterator"
@@ -135,7 +134,7 @@ type BQContext struct {
 func (ctx gcsDatastoreContext) Output(id OutputId, metadata interface{},
 	data []interface{}) (
 	metadataWritten interface{}, dataWritten []interface{}, errs []error) {
-	logger := ctx.Context.Value(shared.DefaultLoggerCtxKey()).(shared.Logger)
+	logger := metrics.GetLogger(ctx.Context)
 
 	if ctx.Bucket.Handle == nil || id.DataLocation.GCSObjectPath == "" {
 		logger.Warningf("GCS configuration incomplete: Skipping output to GCS (bucket handle = %v ; GCS object path = %v)",
@@ -219,7 +218,7 @@ func (ctx gcsDatastoreContext) Output(id OutputId, metadata interface{},
 func (ctx BQContext) Output(id OutputId, metadata interface{},
 	data []interface{}) (metadataWritten interface{},
 	dataWritten []interface{}, errs []error) {
-	logger := ctx.Context.Value(shared.DefaultLoggerCtxKey()).(shared.Logger)
+	logger := metrics.GetLogger(ctx.Context)
 
 	if id.DataLocation.BQDatasetName == "" || id.DataLocation.BQTableName == "" ||
 		id.MetadataLocation.BQDatasetName == "" ||
@@ -345,7 +344,7 @@ func (me multiError) Error() string {
 func (ctx *gcsDatastoreContext) LoadTestRunResults(
 	runs []metrics.TestRunLegacy, limiter Limiter, pretty bool) (
 	runResults []metrics.TestRunResults, err error) {
-	logger := ctx.Context.Value(shared.DefaultLoggerCtxKey()).(shared.Logger)
+	logger := metrics.GetLogger(ctx.Context)
 	resultChan := make(chan metrics.TestRunResults, 0)
 	errChan := make(chan error, 0)
 	runResults = make([]metrics.TestRunResults, 0, 100000)


### PR DESCRIPTION
- Move `metrics/run/` code to `metrics/run/api`
  - I'm not thrilled with this location; should it be `metrics/api`? Something else?
- Switch to flags library that supports tagging structs
  - Flags are now named `--like_this` rather than `-like_this`; `Makefile` updated accordingly
  - Default-value-true not supported; all default-value-true flags renamed to be inverted to preserve default behaviour
- Some flags that should be per-compute-run configurable are API params instead of config params
- When constructing new API config object from flags, preserve existing behaviour: configure output for GCS and BQ
- When using convenience `DefaultStagingComputer()` and `DefaultProdComputer()`, output to GCS only; no one has been using the BQ output tables
- `storage.Outputter` implementations check for complete config; if bits are missing, return `nil, nil, nil` and emit "skipping output" warning
  - This means that, for example, `DefaultStagingComputer()` is expected to emit a warning about skipping BQ output

/CC @Hexcles who will probably use `DefaultStagingComputer()` and `DefaultProdComputer()` instances to kick of metrics computation from results receiver pipeline