### PR TITLE
Add time_start/end fields to legacy format

### DIFF
--- a/metrics/models.go
+++ b/metrics/models.go
@@ -257,6 +257,12 @@ type TestRunLegacy struct {
 	// Time when the test run metadata was first created.
 	CreatedAt time.Time `json:"created_at"`
 
+	// Time when the test run started.
+	TimeStart time.Time `json:"time_start"`
+
+	// Time when the test run ended.
+	TimeEnd time.Time `json:"time_end"`
+
 	// URL for raw results JSON object. Resembles the JSON output of the
 	// wpt report tool.
 	RawResultsURL string `json:"raw_results_url"`


### PR DESCRIPTION
Fixes https://github.com/web-platform-tests/wpt.fyi/issues/682