### PR TITLE
Regenerate data more often

### DIFF
--- a/.github/workflows/update_gh_pages.yml
+++ b/.github/workflows/update_gh_pages.yml
@@ -2,7 +2,7 @@ name: Update gh-pages
 on:
   # Trigger on every three hours, or manually.
   schedule:
-    - cron: '20 /3 * * *'
+    - cron: '20 */3 * * *'
   workflow_dispatch:
 jobs:
   update-gh-pages:

--- a/.github/workflows/update_gh_pages.yml
+++ b/.github/workflows/update_gh_pages.yml
@@ -1,8 +1,8 @@
 name: Update gh-pages
 on:
-  # Trigger on UTC noon daily, or manually.
+  # Trigger on every three hours, or manually.
   schedule:
-    - cron: '0 12 * * *'
+    - cron: '20 /3 * * *'
   workflow_dispatch:
 jobs:
   update-gh-pages:

--- a/build.sh
+++ b/build.sh
@@ -12,7 +12,7 @@ cd results-analysis-cache.git/
 git fetch --all --tags
 cd ../
 
-TO_DATE=$(date -d "yesterday 13:00" '+%Y-%m-%d')
+TO_DATE=$(date -d "tomorrow 13:00" '+%Y-%m-%d')
 
 update_bsf_csv() {
   local OUTPUT="${1}"


### PR DESCRIPTION
Fixes #65.

Now we're regenerating everything from scratch on each run, including BSF, there's no reason to not regenerate everything more often. The only downside here is that we will be changing the results for the yesterday/today on multiple occasions, rather than the figures being mostly constant once they're added.

See https://github.com/Ecosystem-Infra/wpt-results-analysis/pull/70 for some earlier discussion about this basic approach prior to this change.