### PR TITLE
Revert "Regenerate data more often"

### DIFF
--- a/.github/workflows/update_gh_pages.yml
+++ b/.github/workflows/update_gh_pages.yml
@@ -1,8 +1,8 @@
 name: Update gh-pages
 on:
-  # Trigger on every three hours, or manually.
+  # Trigger on UTC noon daily, or manually.
   schedule:
-    - cron: '20 */3 * * *'
+    - cron: '0 12 * * *'
   workflow_dispatch:
 jobs:
   update-gh-pages:

--- a/build.sh
+++ b/build.sh
@@ -12,7 +12,7 @@ cd results-analysis-cache.git/
 git fetch --all --tags
 cd ../
 
-TO_DATE=$(date -d "tomorrow 13:00" '+%Y-%m-%d')
+TO_DATE=$(date -d "yesterday 13:00" '+%Y-%m-%d')
 
 update_bsf_csv() {
   local OUTPUT="${1}"


### PR DESCRIPTION
Reverts web-platform-tests/results-analysis#80

c.f. https://github.com/web-platform-tests/results-analysis/runs/5893361160?check_suite_focus=true

I hadn't realised we failed hard if the run isn't in the cache.