### PR TITLE
Regenerate data more often

### DIFF
--- a/.github/workflows/update_gh_pages.yml
+++ b/.github/workflows/update_gh_pages.yml
@@ -1,8 +1,8 @@
 name: Update gh-pages
 on:
-  # Trigger on UTC noon daily, or manually.
+  # Trigger on every three hours, or manually.
   schedule:
-    - cron: '0 12 * * *'
+    - cron: '20 */3 * * *'
   workflow_dispatch:
 jobs:
   update-gh-pages:

--- a/build.sh
+++ b/build.sh
@@ -12,7 +12,9 @@ cd results-analysis-cache.git/
 git fetch --all --tags
 cd ../
 
-TO_DATE=$(date -d "yesterday 13:00" '+%Y-%m-%d')
+TO_DATE=$(date -d "tomorrow 13:00" '+%Y-%m-%d')
+
+node git-write.js --max-time=300 --max-age-days=5
 
 update_bsf_csv() {
   local OUTPUT="${1}"


### PR DESCRIPTION
Now we're regenerating everything from scratch on each run, including BSF, there's no reason to not regenerate everything more often. The only downside here is that we will be changing the results for the yesterday/today on multiple occasions, rather than the figures being mostly constant once they're added.

See also #80/#81 where we previously landed/reverted this. The only difference here is we run `git-write.js` at the start of `build.sh`, to make sure the local copy of the results has been updated as recently as possible. (Of course, because the various scripts call the wpt.fyi API themselves there is still a risk of a new aligned run appearing between running `git-write.js` and the actual scoring scripts, but that's relatively unlikely.) Ideally we'd update wpt-results-cache on demand from within each script as needed, but that's a much larger change, and also requires dealing with secrets to push to the other repo. This is almost certainly _good enough_ for the vast majority of scheduled jobs, and even if the odd one fails we'll still have more up-to-date results than we had previously.