### PR TITLE
Generate Interop 2022 data for Edge

### DIFF
--- a/interop-2022/main.js
+++ b/interop-2022/main.js
@@ -19,7 +19,7 @@ const path = require('path');
 
 const {advanceDateToSkipBadDataIfNecessary} = require('../bad-ranges');
 
-flags.defineStringList('products', ['chrome', 'firefox', 'safari'],
+flags.defineStringList('products', ['chrome', 'firefox', 'safari', 'edge'],
     'Products to include (comma-separated)');
 flags.defineString('from', '2022-01-01', 'Starting date (inclusive)');
 flags.defineString('to', moment().format('YYYY-MM-DD'),


### PR DESCRIPTION
This is mostly motivated by https://github.com/web-platform-tests/interop-2022/issues/96, but see also https://github.com/web-platform-tests/wpt.fyi/issues/2918 which makes this potentially risky to land (but I deliberately added Edge at the end to try and minimise the risk involved here).