### PR TITLE
Store the full test name while computing BSF

### DIFF
--- a/lib/browser-specific.js
+++ b/lib/browser-specific.js
@@ -255,7 +255,7 @@ function scoreTest(browserTests) {
 
 // Walks a set of trees, one per browser, scoring them for browser-specific
 // failures of tests in the trees.
-function walkTrees(browserTrees) {
+function walkTrees(browserTrees, currentPath) {
   const cacheKey = browserTrees.map(tree => tree.id).join('-');
   if (treesScoreCache.has(cacheKey)) {
     return treesScoreCache.get(cacheKey);
@@ -275,7 +275,9 @@ function walkTrees(browserTrees) {
   while (browserTests.every(tests => tests.hasCurrent())) {
     // If we are looking at the same test across all browsers, but they aren't
     // the exact same objects, they need to be scored!
-    if (browserTests.every(t => t.key() === browserTests[0].key()) &&
+    const testName = browserTests[0].key();
+    const fullTestName = `${currentPath}/${testName}`;
+    if (browserTests.every(t => t.key() === testName) &&
         !browserTests.every(t => t.value() === browserTests[0].value())) {
       try {
         const testScores = scoreTest(
@@ -284,7 +286,7 @@ function walkTrees(browserTrees) {
         browserTests.forEach(t => t.moveNext());
         continue;
       } catch (e) {
-        e.message += `\n\tTest: ${browserTests[0].key()}`;
+        e.message += `\n\tTest: ${fullTestName}`;
         throw e;
       }
     }
@@ -316,9 +318,11 @@ function walkTrees(browserTrees) {
 
     // If all the iterators are pointing at the same directory (subtree), then
     // we should recurse into those subtrees to score them.
-    if (browserSubtrees.every(s => s.key() == browserSubtrees[0].key())) {
+    const dirName = browserSubtrees[0].key();
+    if (browserSubtrees.every(s => s.key() === dirName)) {
       const subtreeScores = walkTrees(
-          browserSubtrees.map(s => s.value()));
+          browserSubtrees.map(s => s.value()),
+          `${currentPath}/${dirName}`);
       scores = scores.map((v, i) => v + subtreeScores[i]);
       browserSubtrees.forEach(s => s.moveNext());
       continue;
@@ -376,7 +380,7 @@ function scoreBrowserSpecificFailures(runs, expectedBrowsers) {
 
 
   // Now do the actual walk to score the runs.
-  const scores = walkTrees(runs.map(run => run.tree));
+  const scores = walkTrees(runs.map(run => run.tree), '');
   return new Map(scores.map((score, i) => [runs[i].browser_name, score]));
 }
 


### PR DESCRIPTION
This allows us to give better error messages, but arguably more importantly is often useful while experimenting with changes to BSF.