### PR TITLE
Add logging over error throwing for non-OK tests

### DIFF
--- a/interop-scoring/main.js
+++ b/interop-scoring/main.js
@@ -157,6 +157,8 @@ const KNOWN_TEST_STATUSES = new Set([
   '/pointerevents/pointerevent_movementxy.html?mouse',
   '/pointerevents/pointerevent_pointercapture_in_frame.html?mouse',
   '/uievents/mouse/attributes.html',
+  // interop-2022-scrolling
+  '/css/css-scroll-snap/snap-at-user-scroll-end.html',
   // interop-2023-webcodecs
   '/webcodecs/videoDecoder-codec-specific.https.any.html?av1',
   '/webcodecs/videoDecoder-codec-specific.https.any.html?h264_annexb',
@@ -274,6 +276,7 @@ function aggregateInteropTestScores(testPassCounts, numBrowsers) {
 function scoreRuns(runs, allTestsSet) {
   const scores = [];
   const testPassCounts = new Map();
+  const unexpectedNonOKTests = new Set();
 
   try {
     for (const run of runs) {
@@ -299,7 +302,7 @@ function scoreRuns(runs, allTestsSet) {
         }
         if ('subtests' in results) {
           if (results['status'] != 'OK' && !KNOWN_TEST_STATUSES.has(testname)) {
-            throw new Error(`Unexpected non-OK status for test: ${testname}`);
+            unexpectedNonOKTests.add(testname);
           }
           subtestTotal = results['subtests'].length;
           for (const subtest of results['subtests']) {
@@ -345,6 +348,14 @@ function scoreRuns(runs, allTestsSet) {
   } catch (e) {
     e.message += `\n\tRuns: ${runs.map(r => r.id)}`;
     throw e;
+  }
+
+  // Log and tests with unexpected non-OK statuses.
+  if (unexpectedNonOKTests.size > 0) {
+    console.log('Unexpected non-OK status for tests:');
+    for (const testname of unexpectedNonOKTests.values()) {
+      console.log(testname);
+    }
   }
   // Calculate the interop scores that have been saved and add
   // the interop score to the end of the browsers' scores array.


### PR DESCRIPTION
This change removes the thrown errors in the interop scoring script that appear when a non-OK test status is observed that has not been documented and instead logs those specific tests after scoring the run. While Interop 2023 test choices are being fleshed out, these non-OK status continue to appear on an almost-daily basis, and are only being added to the list of tests in the code. Each time a new non-OK status appears, the entire series of scripts updating `gh-pages` with run data will fail, and will continue to fail until the run's name is manually added to the list of tests cleared to have a non-OK status.

Due to the situation we're currently in to make the changes for Interop 2023, I believe it is prudent to allow for these non-OK statuses to persist and not impede the updating of the scoring process, and to handle them at a later time if necessary.