### PR TITLE
Make the same logging change for 2022 script

### DIFF
--- a/interop-2022/main.js
+++ b/interop-2022/main.js
@@ -120,6 +120,7 @@ const KNOWN_TEST_STATUSES = new Set([
 //   than if we used rational numbers.
 function scoreRuns(runs, allTestsSet) {
   const scores = [];
+  const unexpectedNonOKTests = new Set();
   try {
     for (const run of runs) {
       // Sum of the integer 0-1000 scores for each test.
@@ -137,7 +138,7 @@ function scoreRuns(runs, allTestsSet) {
         let subtestTotal = 1;
         if ('subtests' in results) {
           if (results['status'] != 'OK' && !KNOWN_TEST_STATUSES.has(testname)) {
-            throw new Error(`Unexpected non-OK status for test: ${testname}`);
+            unexpectedNonOKTests.add(testname);
           }
           subtestTotal = results['subtests'].length;
           for (const subtest of results['subtests']) {
@@ -179,6 +180,13 @@ function scoreRuns(runs, allTestsSet) {
     throw e;
   }
 
+  // Log and tests with unexpected non-OK statuses.
+  if (unexpectedNonOKTests.size > 0) {
+    console.log('Unexpected non-OK status for tests:');
+    for (const testname of unexpectedNonOKTests.values()) {
+      console.log(testname);
+    }
+  }
   return scores;
 }
 


### PR DESCRIPTION
New tests are being added to older tags, which is causing the original script for Interop 2022 to fail when it encounters non-OK statuses. This PR adds the same changes described in #141 to the old 2022 script.