### PR TITLE
Add css-scroll-snap test to list of known non-OK statuses

### DIFF
--- a/interop-2022/main.js
+++ b/interop-2022/main.js
@@ -85,6 +85,8 @@ const KNOWN_TEST_STATUSES = new Set([
   '/html/semantics/forms/the-input-element/range-restore-oninput-onchange-event.html',
   // TIMEOUT in STP 137, since fixed
   '/html/semantics/interactive-elements/the-dialog-element/backdrop-receives-element-events.html',
+  // TIMEOUT for one run in Safari but has since run successfully.
+  '/css/css-scroll-snap/snap-at-user-scroll-end.html',
 ]);
 
 

--- a/interop-scoring/main.js
+++ b/interop-scoring/main.js
@@ -72,6 +72,8 @@ const KNOWN_TEST_STATUSES = new Set([
   '/html/semantics/forms/the-input-element/range-restore-oninput-onchange-event.html',
   // TIMEOUT in STP 137, since fixed
   '/html/semantics/interactive-elements/the-dialog-element/backdrop-receives-element-events.html',
+  // TIMEOUT for one run in Safari but has since run successfully.
+  '/css/css-scroll-snap/snap-at-user-scroll-end.html',
 
 
   /**


### PR DESCRIPTION
This test had a transient timeout error on 2023-01-21 that not been repeated since. See #143.