### PR TITLE
Use URLSearchParams to construct wpt.fyi API URLs

### DIFF
--- a/lib/runs.js
+++ b/lib/runs.js
@@ -9,14 +9,14 @@ const {advanceDateToSkipBadDataIfNecessary} = require('../bad-ranges');
 const RUNS_API = 'https://wpt.fyi/api/runs';
 
 function apiURL(options = {}) {
-  const queryParts = Object.entries(options).map(([name, value]) => {
+  const url = new URL(RUNS_API);
+  for (let [name, value] of Object.entries(options)) {
     if (Array.isArray(value)) {
       value = value.join(',');
     }
-    return `${encodeURIComponent(name)}=${encodeURIComponent(value)}`;
-  });
-  const query = queryParts.join('&');
-  return `${RUNS_API}?${query}`;
+    url.searchParams.set(name, value);
+  }
+  return url;
 }
 
 async function get(options) {
@@ -64,7 +64,8 @@ async function* getIterator(options) {
       break;
     }
     previousUrl = url;
-    url = `${RUNS_API}?page=${token}`;
+    url = new URL(RUNS_API);
+    url.searchParams.set('page', token);
   }
 }
 


### PR DESCRIPTION
This should be a no-op change, but takes care of escaping of names and
values in a simpler way, and if it should be needed for the page token.
