### PR TITLE
Ignore major version updates for "node-fetch"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,6 @@ updates:
   directory: /
   schedule:
     interval: monthly
+  ignore:
+      - dependency-name: "node-fetch"
+        update-types: ["version-update:semver-major"]"


### PR DESCRIPTION
We don't have sufficient test coverage to know if version 3 is a safe upgrade, so it would be nice to make the bot less noisy.