### PR TITLE
Freeze previous Interop year scores

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -94,14 +94,17 @@ update_interop_2022 out/data/interop-2022/
 
 update_interop_year() {
   local YEAR="${1}"
+  local END_DATE="${2}"
 
   mkdir -p out/data/interop-${YEAR}/
-  node interop-scoring/main.js --year=${YEAR} --to=${TO_DATE}
-  node interop-scoring/main.js --year=${YEAR} --to=${TO_DATE} --experimental
+  node interop-scoring/main.js --year=${YEAR} --to=${END_DATE}
+  node interop-scoring/main.js --year=${YEAR} --to=${END_DATE} --experimental
 
   mv interop-${YEAR}-*.csv out/data/interop-${YEAR}/
 }
 
-update_interop_year 2021
-update_interop_year 2022
-update_interop_year 2023
+# End date should be end of the interop year,
+# or the current date if it is the current interop year.
+update_interop_year 2021 "2022-01-01"
+update_interop_year 2022 "2023-01-01"
+update_interop_year 2023 $TO_DATE

--- a/build.sh
+++ b/build.sh
@@ -107,4 +107,5 @@ update_interop_year() {
 # or the current date if it is the current interop year.
 update_interop_year 2021 "2022-01-01"
 update_interop_year 2022 "2023-01-01"
+# TODO(DanielRyanSmith): 2023 should end with "2024-01-01" once interop 2024 has begun.
 update_interop_year 2023 $TO_DATE


### PR DESCRIPTION
This change stops the previous interop scores from updating with score data after the interop year is over. This means that compat 2021 and interop 2022 scores are only populated with data up to the end of that year. This also has the effect of making these scripts a bit more scalable, as the work for previous years will not grow with the current interop year.