### PR TITLE
Remove interop scoring runs for previous years

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -46,6 +46,4 @@ update_interop_year() {
   mv interop-${YEAR}-*.csv out/data/interop-${YEAR}/
 }
 
-update_interop_year 2021
-update_interop_year 2022
 update_interop_year 2023


### PR DESCRIPTION
This change should only be landed after https://github.com/web-platform-tests/wpt.fyi/pull/3293.

The interop scores for previous years will be read from a static file in the Interop Dashboard in order to "freeze" the scores to their end-of-year totals. This means that the CSVs for previous interop years will no longer need to be generated automatically. This change stops those score files from being generated and updated from this repository.