### PR TITLE
Treat 'PRECONDITION_FAILED' as 'PASS' for interop scoring purposes

### DIFF
--- a/interop-scoring/main.js
+++ b/interop-scoring/main.js
@@ -310,12 +310,12 @@ function scoreRuns(runs, allTestsSet) {
           }
           subtestTotal = results['subtests'].length;
           for (const subtest of results['subtests']) {
-            if (subtest['status'] == 'PASS') {
+            if (subtest['status'] == 'PASS' || subtest['status'] == 'PRECONDITION_FAILED') {
               subtestPasses += 1;
             }
           }
         } else {
-          if (results['status'] == 'PASS') {
+          if (results['status'] == 'PASS' || subtest['status'] == 'PRECONDITION_FAILED') {
             subtestPasses = 1;
           }
         }


### PR DESCRIPTION
'PRECONDITION_FAILED' means that the condition tested by  `assert_implements_optional` is `false`.

For instance, a test might test multiple times the same feature with different video/audio codecs that are optional. If the codec is not supported, 'PRECONDITION_FAILED' would be returned as status.

https://web-platform-tests.org/writing-tests/testharness-api.html#optional-features

This is different from the API not being supported, in that case, `assert_implements_optional` would fail with an exception (since it couldn't evaluate the condition), and the status would be 'ERROR'.