### PR TITLE
Exclude 2023-07-17 (only) as a bad range (stable)

### DIFF
--- a/bad-ranges.js
+++ b/bad-ranges.js
@@ -20,6 +20,8 @@ const STABLE_BAD_RANGES = [
   // This was a regression from https://github.com/web-platform-tests/wpt/pull/29089,
   // fixed by https://github.com/web-platform-tests/wpt/pull/32540
   [moment('2022-01-25'), moment('2022-01-27')],
+  // This was a very much incomplete Safari run.
+  [moment('2023-07-17'), moment('2023-07-18')],
 ];
 
 const EXPERIMENTAL_BAD_RANGES = [


### PR DESCRIPTION
See https://wpt.fyi/results/?q=status%3Amissing&run_id=6282678108684288&run_id=5163365977030656&run_id=5090383543926784