### PR TITLE
Fix #126: be slightly forgiving on dates of runs

### DIFF
--- a/lib/runs.js
+++ b/lib/runs.js
@@ -92,10 +92,15 @@ async function fetchAlignedRunsFromServer(products, from, to, experimental) {
   const before = moment();
   const noCacheAfter = moment().subtract('3', 'days');
   const alignedRuns = new Map();
+
   while (from < to) {
-    const formattedFrom = from.format('YYYY-MM-DD');
+    const yesterday = moment(from).subtract(1, 'days');
+    const today = moment(from);
     from.add(1, 'days');
-    const formattedTo = from.format('YYYY-MM-DD');
+    const tomorrow = moment(from);
+
+    const formattedFrom = yesterday.format('YYYY-MM-DD');
+    const formattedTo = tomorrow.format('YYYY-MM-DD');
 
     // We advance the date (if necessary) before doing anything more, so that
     // code later in the loop body can just 'continue' without checking.
@@ -105,7 +110,7 @@ async function fetchAlignedRunsFromServer(products, from, to, experimental) {
     // TODO: Consider https://github.com/tidoust/fetch-filecache-for-crawling
     let runs;
     const cacheFile = path.join(path.join(__dirname, '..'),
-        `cache/${label}-${products.join('-')}-runs-${formattedFrom}.json`);
+        `cache/${label}-${products.join('-')}-runs-${formattedFrom}-${formattedTo}.json`);
     try {
       runs = JSON.parse(await fs.promises.readFile(cacheFile));
       if (runs.length) {
@@ -134,7 +139,11 @@ async function fetchAlignedRunsFromServer(products, from, to, experimental) {
           `Fetched ${runs.length} runs, expected ${products.length}`);
     }
 
-    alignedRuns.set(formattedFrom, runs);
+    if (!runs.some((run) => moment(run.time_start, moment.ISO_8601).isSame(today, "day"))) {
+      continue;
+    }
+
+    alignedRuns.set(today.format('YYYY-MM-DD'), runs);
   }
   const after = moment();
   console.log(`Fetched ${alignedRuns.size} sets of runs in ` +


### PR DESCRIPTION
Previously, aligned runs were only found if they have a time_start value that falls within the date being queried for, and if one or more of the runs that would be considered aligned started outside of this, then those runs will not be considered aligned and returned.

Instead, allow runs which started either on the date being queried for or the day before, and treat the returned runs as a return for the appropriate date provided at least one run started on that date (thereby avoiding returning a run which was valid for the previous day).

We could increase the amount of fuzziness allowed here, but it increases the probability of ending up with a significantly mismatched run appearing out-of-order.