### PR TITLE
Exclude 09-20-2023 (only) as a bad range (experimental)

### DIFF
--- a/bad-ranges.js
+++ b/bad-ranges.js
@@ -44,6 +44,7 @@ const EXPERIMENTAL_BAD_RANGES = [
   // These were very much incomplete Safari runs.
   [moment('2023-09-02'), moment('2023-09-03')],
   [moment('2023-09-11'), moment('2023-09-12')],
+  [moment('2023-09-20'), moment('2023-09-20')],
 ];
 
 // Advances date to the end of a bad range if it's in a bad range, and otherwise


### PR DESCRIPTION
See https://wpt.fyi/results/?q=status%3Amissing&run_id=4794973548969984&run_id=5157687253270528