### PR TITLE
Exclude 2023-09-20 as a bad-range on stable

### DIFF
--- a/bad-ranges.js
+++ b/bad-ranges.js
@@ -22,6 +22,9 @@ const STABLE_BAD_RANGES = [
   [moment('2022-01-25'), moment('2022-01-27')],
   // This was a very much incomplete Safari run.
   [moment('2023-07-17'), moment('2023-07-18')],
+  // Safari got a lot of broken screenshots.
+  // https://bugs.webkit.org/show_bug.cgi?id=262078
+  [moment('2023-09-19'), moment('2023-09-20')],
 ];
 
 const EXPERIMENTAL_BAD_RANGES = [

--- a/bad-ranges.js
+++ b/bad-ranges.js
@@ -24,7 +24,7 @@ const STABLE_BAD_RANGES = [
   [moment('2023-07-17'), moment('2023-07-18')],
   // Safari got a lot of broken screenshots.
   // https://bugs.webkit.org/show_bug.cgi?id=262078
-  [moment('2023-09-19'), moment('2023-09-20')],
+  [moment('2023-09-20'), moment('2023-09-21')],
 ];
 
 const EXPERIMENTAL_BAD_RANGES = [


### PR DESCRIPTION
c.f. https://wpt.fyi/results/?q=seq%28status%3Apass%20status%3A%21pass%20status%3Apass%29&run_id=5179945829007360&run_id=5129256222326784&run_id=5105446492307456 &  https://bugs.webkit.org/show_bug.cgi?id=262078