### PR TITLE
Update web-platform-tests/results-analysis-cache with all products

### DIFF
--- a/git-write.js
+++ b/git-write.js
@@ -156,7 +156,26 @@ async function main() {
   const deadline = maxTime ? Date.now() + 1000 * maxTime : NaN;
   const maxAge = maxAgeDays ? moment().subtract(maxAgeDays, 'days') : null;
 
-  const products = ['chrome', 'edge', 'firefox', 'safari', 'webkitgtk'];
+  const products = [
+    'android_webview',
+    'chrome',
+    'chrome_android',
+    'chrome_ios',
+    'chromium',
+    'deno',
+    'edge',
+    'epiphany',
+    'firefox',
+    'firefox_android',
+    'flow',
+    'node.js',
+    'safari',
+    'servo',
+    'uc',
+    'webkitgtk',
+    'wktr',
+  ];
+
   for (const product of products) {
     let productRuns = 0;
     let stop = false;

--- a/lib/runs.js
+++ b/lib/runs.js
@@ -47,8 +47,9 @@ async function* getIterator(options) {
   let previousUrl = null;
   while (true) {
     const r = await fetch(url);
-    if (!r.ok) {
-      let msg = `non-OK fetch status ${r.status} when fetching ${url}`;
+    // wpt.fyi API returns 404 with an empty result set
+    if (!r.ok && r.status !== 404) {
+      let msg = `non-OK, non-404 fetch status ${r.status} when fetching ${url}`;
       if (previousUrl) {
         msg += ` (previous url was ${previousUrl})`;
       }


### PR DESCRIPTION
We might want to start scoring mobile browsers (such as Android WebView, Chrome for Android, Chrome for iOS, or Firefox for Android) in the future, and back-filling the cache is painfully slow (as it requires downloading each run). Instead, let's just add every product to the cache, because it doesn't have a particularly significant affect on the overall size of the repo.

FWIW, I've run this manually (which takes many, many, many hours), so I can push all the new data to the cache, rather than have the GitHub Actions job struggle to do this in its time-boxed segments.