### PR TITLE
Remove chrome_ios as a product

### DIFF
--- a/git-write.js
+++ b/git-write.js
@@ -160,7 +160,6 @@ async function main() {
     'android_webview',
     'chrome',
     'chrome_android',
-    'chrome_ios',
     'chromium',
     'deno',
     'edge',


### PR DESCRIPTION
Regression from https://github.com/web-platform-tests/results-analysis/pull/199, because while that was awaiting review the product got removed from wpt.fyi: https://github.com/web-platform-tests/wpt.fyi/commit/8a13f910ce6c77f37ef993a4e39f366fd5babb8b