### PR TITLE
Include interop-2021-grid in interop-2024-layout

### DIFF
--- a/interop-scoring/category-data.json
+++ b/interop-scoring/category-data.json
@@ -389,6 +389,7 @@
         "name": "interop-2024-layout",
         "labels": [
           "interop-2021-flexbox",
+          "interop-2021-grid",
           "interop-2023-flexbox",
           "interop-2023-grid",
           "interop-2022-subgrid"


### PR DESCRIPTION
It's already included in the links in https://github.com/web-platform-tests/wpt.fyi/pull/3662.