### PR TITLE
Update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,16 @@ updates:
   schedule:
     interval: monthly
   ignore:
+      - dependency-name: "chai"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "flags"
+        update-types: ["version-update:semver-minor"]
       - dependency-name: "node-fetch"
         update-types: ["version-update:semver-major"]
 
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: monthly


### PR DESCRIPTION
Exclude more npm packages which we can't update pending https://github.com/web-platform-tests/results-analysis/issues/232, and start updating GitHub Actions.