### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - uses: awalsh128/cache-apt-pkgs-action@v1
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
         version: 1.0
 
     - name: Setup Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: '18'
         cache: 'npm'

--- a/.github/workflows/update_gh_pages.yml
+++ b/.github/workflows/update_gh_pages.yml
@@ -12,7 +12,7 @@ jobs:
   update-gh-pages:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - uses: awalsh128/cache-apt-pkgs-action@v1
       with:

--- a/.github/workflows/update_gh_pages.yml
+++ b/.github/workflows/update_gh_pages.yml
@@ -20,7 +20,7 @@ jobs:
         version: 1.0
 
     - name: Setup Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: '18'
         cache: 'npm'


### PR DESCRIPTION
Even prior to #233, we might want to update these actions. We're currently getting warnings when running these: https://github.com/web-platform-tests/results-analysis/actions/runs/11058228856