### PR TITLE
Remove 2023 aggregation from script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -47,5 +47,4 @@ update_interop_year() {
   mv interop-${YEAR}-*.csv out/data/interop-${YEAR}/
 }
 
-update_interop_year 2023 chrome,firefox,safari
 update_interop_year 2024 chrome,edge,firefox,safari


### PR DESCRIPTION
This is no longer needed, as the 2023 scores are read from [a static file in the wpt.fyi repo](https://github.com/web-platform-tests/wpt.fyi/blob/main/webapp/static/interop-2023-experimental.csv).