### PR TITLE
Use total tests expected for Interop score aggregation

### DIFF
--- a/interop-scoring/main.js
+++ b/interop-scoring/main.js
@@ -225,7 +225,7 @@ const KNOWN_TEST_STATUSES = new Set([
 // subtest results. Due to some missing subtests, this score skewed lower than the
 // current implementation. Neither is without its drawbacks, and the hope is that
 // the current approach will score runs more optimistically and avoid subtest matching.
-function aggregateInteropTestScores(testPassCounts, numBrowsers) {
+function aggregateInteropTestScores(testPassCounts, numBrowsers, numTotalTests) {
   if (testPassCounts.size === 0) return 0;
   let aggregateScore = 0;
   for (const testResults of testPassCounts.values()) {
@@ -244,7 +244,7 @@ function aggregateInteropTestScores(testPassCounts, numBrowsers) {
     // Add the minimum test score to the aggregate interop score.
     aggregateScore += Math.floor(1000 * minTestScore);
   }
-  return Math.floor(aggregateScore / testPassCounts.size) || 0;
+  return Math.floor(aggregateScore / numTotalTests) || 0;
 }
 
 // Score a set of runs (independently) on a set of tests. The runs are presumed
@@ -281,7 +281,6 @@ function scoreRuns(runs, allTestsSet) {
   const scores = [];
   const testPassCounts = new Map();
   const unexpectedNonOKTests = new Set();
-
   try {
     for (const run of runs) {
       // Sum of the integer 0-1000 scores for each test.
@@ -363,7 +362,7 @@ function scoreRuns(runs, allTestsSet) {
   }
   // Calculate the interop scores that have been saved and add
   // the interop score to the end of the browsers' scores array.
-  scores.push(aggregateInteropTestScores(testPassCounts, runs.length));
+  scores.push(aggregateInteropTestScores(testPassCounts, runs.length, allTestsSet.size));
   return scores;
 }
 


### PR DESCRIPTION
This change fixes an issue in which past Interop scores (displayed in the graph on the dashboard) will sometimes be inaccurate. The Interop scores were being calculated using the total number of tests found within the set of runs, rather than the number of test that were labeled in the metadata. This means that the Interop scores were essentially being calculated as the value of the Interop score during that run's date, rather than what that Interop scores should be today.

This bug only affects focus areas that have had their labeled tests change during the Interop year, and also does not affect the calculations for past browser scores, which is why the Interop score was occasionally displaying as higher than individual browser scores.

Within the scoring script is an explanation of why we want to aggregate the scores this way:
```
      // We always normalize against the number of tests we are looking for,
      // rather than the total number of tests we found. The trade-off is all
      // about new tests being added to the set.
      //
      // If a large chunk of tests are introduced at date X, and they fail in
      // some browser, then runs after date X look worse if you're only
      // counting total tests found - even though the tests would have failed
      // before date X as well.
      //
      // Conversely, if a large chunk of tests are introduced at date X, and
      // they pass in some browser, then runs after date X would get an
      // artificial boost in pass-rate due to this - even if the tests would
      // have passed before date X as well.
      //
      // We consider the former case worse than the latter, so optimize for it
      // by always comparing against the full test list. This does mean that
      // when tests are added to the set, previously generated data is no
      // longer valid and this script should be re-run for all dates.
   ```