### PR TITLE
Stop generating Interop 2024 scores

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -47,5 +47,4 @@ update_interop_year() {
   mv interop-${YEAR}-*.csv out/data/interop-${YEAR}/
 }
 
-update_interop_year 2024 chrome,edge,firefox,safari
 update_interop_year 2025 chrome,edge,firefox,safari


### PR DESCRIPTION
The Interop 2024 scores are now frozen and read from a static file in wpt.fyi, so generating these scores is no longer needed.