### PR TITLE
Update browser scoring for Servo

### DIFF
--- a/lib/browser-specific.js
+++ b/lib/browser-specific.js
@@ -7,7 +7,7 @@
  * browser (aka browser-specific failures).
  */
 
-const TEST_PASS_STATUSES = ['PASS'];
+const TEST_PASS_STATUSES = ['OK', 'PASS'];
 const TEST_FAIL_STATUSES = ['FAIL', 'ERROR', 'TIMEOUT', 'CRASH'];
 // An empty string has been seen for some tests; see
 // https://github.com/web-platform-tests/wpt/issues/22306
@@ -383,7 +383,7 @@ function scoreBrowserSpecificFailures(runs, expectedBrowsers) {
 
   // Now do the actual walk to score the runs.
   const scores = walkTrees(runs.map(run => run.tree), '');
-  return new Map(scores.map((score, i) => [runs[i].browser_name, score]));
+  return new Map(scores.map((score, i) => [runs[i].browser_name, Math.floor(score)]));
 }
 
 module.exports = {scoreBrowserSpecificFailures};


### PR DESCRIPTION
While trying to compute the score of Servo, I ran into the issue that tests reported as "OK" would crash. This is a valid test status as reported by the API [1].

Additionally, while trying to plot the scores, I saw that all numbers are shown as floats. This makes analysis a bit more difficult and appears to also show on the dashboard on https://wpt.fyi/results/

Therefore, floor all scores to result in whole numbers.

[1]: https://github.com/web-platform-tests/wpt.fyi/blob/main/api/README.md#apiresults