### PR TITLE
[DRAFT] Add scaffolding for feature-level interop scoring

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -43,6 +43,23 @@ update_bsf_csv out/data/experimental-browser-specific-failures.csv
 update_bsf_csv out/data/stable-browser-specific-failures-with-third-party.csv
 update_bsf_csv out/data/experimental-browser-specific-failures-with-third-party.csv
 
+# TODO: feature-level-interop.js is scaffolding only; it parses these flags but
+# does not score anything or write a CSV yet.
+update_feature_level_interop_csv() {
+  local OUTPUT="${1}"
+
+  local FROM_DATE="2018-06-01"
+  local EXPERIMENTAL_FLAG=""
+  if [[ $1 == *"experimental"* ]]; then
+    EXPERIMENTAL_FLAG="--experimental"
+  fi
+
+  node feature-level-interop.js \
+    ${EXPERIMENTAL_FLAG} \
+    --from=${FROM_DATE} --to=${TO_DATE} \
+    --output=${OUTPUT}
+}
+
 update_interop_year() {
   local YEAR="${1}"
   local PRODUCTS="${2}"
@@ -55,3 +72,6 @@ update_interop_year() {
 }
 
 update_interop_year 2026 chrome,edge,firefox,safari
+
+update_feature_level_interop_csv out/data/stable-feature-level-interop.csv
+update_feature_level_interop_csv out/data/experimental-feature-level-interop.csv

--- a/feature-level-interop.js
+++ b/feature-level-interop.js
@@ -1,0 +1,58 @@
+'use strict';
+
+/**
+ * Implements a view of how interoperable each web feature is over time.
+ */
+
+const flags = require('flags');
+const moment = require('moment');
+
+flags.defineString('from', '2018-07-01', 'Starting date (inclusive)');
+flags.defineString('to', moment().format('YYYY-MM-DD'),
+    'Ending date (exclusive)');
+flags.defineStringList('products', ['chrome', 'firefox', 'safari'],
+    'Browsers to compare. Must match the products used on wpt.fyi');
+flags.defineString('output', null,
+    'Output CSV file to write to. Defaults to ' +
+    '{stable, experimental}-feature-level-interop.csv');
+flags.defineBoolean('experimental', false,
+    'Calculate metrics for experimental runs.');
+flags.parse();
+
+
+// TODO: Score feature-level interoperability, following the same shape as
+// browser-specific-failures.js: open the results-analysis-cache repo, fetch
+// aligned runs, load each run's tree, score per date, and write one CSV row
+// per date. For now only the flags are parsed.
+async function main() {
+  // Sort the products so that output files are consistent.
+  const products = flags.get('products');
+  if (products.length < 2) {
+    throw new Error('At least 2 products must be specified for this analysis');
+  }
+  products.sort();
+
+  // First, grab aligned runs from the server for the dates that we are
+  // interested in.
+  const from = moment(flags.get('from'));
+  const to = moment(flags.get('to'));
+  const experimental = flags.get('experimental');
+
+  console.log(`Scoring ${products.join(', ')} from ` +
+      `${from.format('YYYY-MM-DD')} to ${to.format('YYYY-MM-DD')}`);
+
+  // Finally, time to dump stuff.
+  let outputFilename = flags.get('output');
+  if (!outputFilename) {
+    outputFilename = experimental ?
+        'experimental-feature-level-interop.csv' :
+        'stable-feature-level-interop.csv';
+  }
+
+  console.log(`Writing data to ${outputFilename}`);
+}
+
+main().catch(reason => {
+  console.error(reason);
+  process.exit(1);
+});


### PR DESCRIPTION
Adds feature-level-interop.js (based off of browser-specific-failures.js)
and extends build.sh to call into it with the expected arguments.

Note that feature level interop is just a stub at the moment, with
the logic for feature group, scoring, etc to be implemented after
further discussion with the interop team.

Feature level scoring will depend on labeling in the web-platform-dx/web-features project.
Scoring by test count alone lets features with thousands of tests dominate those
with only a handful, and an aggregate pass rate/count says more about how tests
are written than about how interoperable the web actually is.