### PR TITLE
Add web features manifest fetching

### DIFF
--- a/lib/runs.js
+++ b/lib/runs.js
@@ -4,9 +4,18 @@ const fetch = require('node-fetch');
 const fs = require('fs');
 const moment = require('moment');
 const path = require('path');
+const zlib = require('zlib');
 const {advanceDateToSkipBadDataIfNecessary} = require('../bad-ranges');
 
 const RUNS_API = 'https://wpt.fyi/api/runs';
+
+// The web features manifest is published as a release asset on every
+// web-platform-tests/wpt release. Assets are named with the revision they were
+// built from, so we match on the label, which does not change; wpt.fyi does the
+// same in shared/web_features_manifest_github_download.go.
+const WPT_RELEASE_API =
+    'https://api.github.com/repos/web-platform-tests/wpt/releases/latest';
+const WEB_FEATURES_MANIFEST_LABEL = 'WEB_FEATURES_MANIFEST.json.gz';
 
 function apiURL(options = {}) {
   const url = new URL(RUNS_API);
@@ -159,4 +168,62 @@ async function fetchAlignedRunsFromServer(products, from, to, experimental) {
   return alignedRuns;
 }
 
-module.exports = {get, getAll, getIterator, fetchAlignedRunsFromServer};
+// Returns the web features manifest asset of a wpt release, as returned by the
+// GitHub releases API. Matches on the asset label rather than its name, which
+// carries the revision the manifest was built from.
+function findWebFeaturesManifestAsset(release) {
+  const asset = release['assets'].find(
+      a => a['label'] === WEB_FEATURES_MANIFEST_LABEL);
+  if (!asset) {
+    throw new Error(
+        `No ${WEB_FEATURES_MANIFEST_LABEL} asset on ${release['tag_name']}`);
+  }
+  return asset;
+}
+
+// Parses the gzipped web features manifest in |buffer|, returning a map from
+// feature to the set of tests that make up that feature. The manifest holds
+// {version, data}, where data maps each feature to a list of test paths.
+function parseWebFeaturesManifest(buffer) {
+  const manifest = JSON.parse(zlib.gunzipSync(buffer));
+  if (manifest['version'] !== 1) {
+    throw new Error(
+        `Unknown web features manifest version ${manifest['version']}`);
+  }
+
+  // Map from features to tests, as with the labeled tests in
+  // interop-scoring/main.js.
+  const featureTests = new Map();
+  for (const [feature, tests] of Object.entries(manifest['data'])) {
+    featureTests.set(feature, new Set(tests));
+  }
+  return featureTests;
+}
+
+// Fetches the web features manifest from the latest wpt release and returns a
+// map from feature to the set of tests that make up that feature.
+async function fetchWebFeaturesManifest() {
+  const releaseResponse = await fetch(WPT_RELEASE_API);
+  if (!releaseResponse.ok) {
+    throw new Error(`non-OK fetch status ${releaseResponse.status} when ` +
+        `fetching ${WPT_RELEASE_API}`);
+  }
+  const asset = findWebFeaturesManifestAsset(await releaseResponse.json());
+
+  const assetResponse = await fetch(asset['browser_download_url']);
+  if (!assetResponse.ok) {
+    throw new Error(`non-OK fetch status ${assetResponse.status} when ` +
+        `fetching ${asset['browser_download_url']}`);
+  }
+  return parseWebFeaturesManifest(await assetResponse.buffer());
+}
+
+module.exports = {
+  get,
+  getAll,
+  getIterator,
+  fetchAlignedRunsFromServer,
+  fetchWebFeaturesManifest,
+  findWebFeaturesManifestAsset,
+  parseWebFeaturesManifest,
+};

--- a/test/runs.js
+++ b/test/runs.js
@@ -1,0 +1,123 @@
+'use strict';
+
+const assert = require('chai').assert;
+const zlib = require('zlib');
+
+const runs = require('../lib/runs');
+
+const MANIFEST_LABEL = 'WEB_FEATURES_MANIFEST.json.gz';
+
+// Builds a release asset as returned by the GitHub releases API.
+function createAsset(name, label) {
+  return {
+    'name': name,
+    'label': label,
+    'browser_download_url': `https://example.com/${name}`,
+  };
+}
+
+// Builds a release payload as returned by the GitHub releases API.
+function createRelease(assets) {
+  return {'tag_name': 'merge_pr_12345', 'assets': assets};
+}
+
+// Builds a gzipped manifest, as published on a wpt release.
+function createManifest(version, data) {
+  return zlib.gzipSync(JSON.stringify({version, data}));
+}
+
+describe('runs.js', () => {
+  describe('findWebFeaturesManifestAsset', () => {
+    it('should find the asset with the manifest label', () => {
+      const asset = createAsset(
+          'WEB_FEATURES_MANIFEST_abcdef.json.gz', MANIFEST_LABEL);
+      const release = createRelease([
+        createAsset('MANIFEST-abcdef.json.gz', 'MANIFEST.json.gz'),
+        asset,
+      ]);
+
+      assert.strictEqual(runs.findWebFeaturesManifestAsset(release), asset);
+    });
+
+    it('should match on the label rather than the name', () => {
+      // The asset that is named like the manifest is not the labeled one, so
+      // matching on the name would pick the wrong asset.
+      const asset = createAsset(
+          'WEB_FEATURES_MANIFEST_abcdef.json.gz', MANIFEST_LABEL);
+      const release = createRelease([
+        createAsset(MANIFEST_LABEL, 'SOMETHING_ELSE.json.gz'),
+        asset,
+      ]);
+
+      assert.strictEqual(runs.findWebFeaturesManifestAsset(release), asset);
+    });
+
+    it('should throw if no asset has the manifest label', () => {
+      const release = createRelease([
+        createAsset('MANIFEST-abcdef.json.gz', 'MANIFEST.json.gz'),
+      ]);
+
+      assert.throws(() => {
+        runs.findWebFeaturesManifestAsset(release);
+      }, /No WEB_FEATURES_MANIFEST\.json\.gz asset on merge_pr_12345/);
+    });
+
+    it('should throw if the release has no assets', () => {
+      const release = createRelease([]);
+
+      assert.throws(() => {
+        runs.findWebFeaturesManifestAsset(release);
+      }, /No WEB_FEATURES_MANIFEST\.json\.gz asset on merge_pr_12345/);
+    });
+  });
+
+  describe('parseWebFeaturesManifest', () => {
+    it('should map each feature to its set of tests', () => {
+      const manifest = createManifest(1, {
+        'grid': ['/css/css-grid/a.html', '/css/css-grid/b.html'],
+        'anchor-positioning': ['/css/css-anchor-position/c.html'],
+      });
+
+      const featureTests = runs.parseWebFeaturesManifest(manifest);
+
+      assert.deepEqual(featureTests, new Map([
+        ['grid', new Set(['/css/css-grid/a.html', '/css/css-grid/b.html'])],
+        ['anchor-positioning', new Set(['/css/css-anchor-position/c.html'])],
+      ]));
+    });
+
+    it('should treat duplicate tests in a feature as one', () => {
+      const manifest = createManifest(1, {
+        'grid': ['/css/css-grid/a.html', '/css/css-grid/a.html'],
+      });
+
+      const featureTests = runs.parseWebFeaturesManifest(manifest);
+
+      assert.deepEqual(featureTests, new Map([
+        ['grid', new Set(['/css/css-grid/a.html'])],
+      ]));
+    });
+
+    it('should return an empty map for a manifest with no features', () => {
+      const featureTests = runs.parseWebFeaturesManifest(createManifest(1, {}));
+
+      assert.deepEqual(featureTests, new Map());
+    });
+
+    it('should throw for an unknown manifest version', () => {
+      const manifest = createManifest(2, {'grid': ['/css/css-grid/a.html']});
+
+      assert.throws(() => {
+        runs.parseWebFeaturesManifest(manifest);
+      }, /Unknown web features manifest version 2/);
+    });
+
+    it('should throw for a manifest with no version', () => {
+      const manifest = zlib.gzipSync(JSON.stringify({data: {}}));
+
+      assert.throws(() => {
+        runs.parseWebFeaturesManifest(manifest);
+      }, /Unknown web features manifest version undefined/);
+    });
+  });
+});


### PR DESCRIPTION
Adds lib.runs.fetchWebFeaturesManifest, which downloads the
WEB_FEATURES_MANIFEST.json.gz asset from the latest web-platform-tests/wpt
release and returns a map from each web feature to the set of tests that make
up that feature.

Assets are named with the wpt revision they were built from, so the asset is
matched on its label instead, which does not change between releases. wpt.fyi
matches the same way in shared/web_features_manifest_github_download.go.

Nothing calls this yet; it will be used to score interoperability per web
feature.