### PR TITLE
Add scaffolding for feature-level interop scoring

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -43,6 +43,25 @@ update_bsf_csv out/data/experimental-browser-specific-failures.csv
 update_bsf_csv out/data/stable-browser-specific-failures-with-third-party.csv
 update_bsf_csv out/data/experimental-browser-specific-failures-with-third-party.csv
 
+# TODO: Call update_feature_level_interop_csv once feature-level-interop.js
+# scores the runs and writes a CSV. It currently only loads the aligned runs,
+# their result trees and the web features manifest, so running it here would
+# cost a full load of every run without producing any output.
+update_feature_level_interop_csv() {
+  local OUTPUT="${1}"
+
+  local FROM_DATE="2018-06-01"
+  local EXPERIMENTAL_FLAG=""
+  if [[ $1 == *"experimental"* ]]; then
+    EXPERIMENTAL_FLAG="--experimental"
+  fi
+
+  node feature-level-interop.js \
+    ${EXPERIMENTAL_FLAG} \
+    --from=${FROM_DATE} --to=${TO_DATE} \
+    --output=${OUTPUT}
+}
+
 update_interop_year() {
   local YEAR="${1}"
   local PRODUCTS="${2}"

--- a/feature-level-interop.js
+++ b/feature-level-interop.js
@@ -1,0 +1,69 @@
+'use strict';
+
+/**
+ * Implements a view of web interoperability per web feature over time.
+ *
+ * This is currently just the framework: the aligned runs, their result trees
+ * and the feature to test mapping are all loaded, but the runs are not scored
+ * yet.
+ */
+
+const flags = require('flags');
+const Git = require('nodegit');
+const lib = require('./lib');
+const moment = require('moment');
+
+flags.defineString('from', '2018-07-01', 'Starting date (inclusive)');
+flags.defineString('to', moment().format('YYYY-MM-DD'),
+    'Ending date (exclusive)');
+flags.defineStringList('products', ['chrome', 'firefox', 'safari'],
+    'Browsers to compare. Must match the products used on wpt.fyi');
+flags.defineString('output', null,
+    'Output CSV file to write to. Defaults to ' +
+    '{stable, experimental}-feature-level-interop.csv');
+flags.defineBoolean('experimental', false,
+    'Calculate metrics for experimental runs.');
+flags.parse();
+
+
+async function main() {
+  // Sort the products so that output files are consistent.
+  const products = flags.get('products');
+  if (products.length < 2) {
+    throw new Error('At least 2 products must be specified for this analysis');
+  }
+  products.sort();
+
+  const repo = await Git.Repository.open('results-analysis-cache.git');
+
+  // First, grab aligned runs from the server for the dates that we are
+  // interested in.
+  const from = moment(flags.get('from'));
+  const to = moment(flags.get('to'));
+  const experimental = flags.get('experimental');
+  const alignedRuns = await lib.runs.fetchAlignedRunsFromServer(
+      products, from, to, experimental);
+
+  // Work out which tests make up each web feature. This is done before the
+  // trees are loaded, so that a failure here does not throw away that work.
+  console.log('Fetching the web features manifest');
+  const before = Date.now();
+  const featureTests = await lib.runs.fetchWebFeaturesManifest();
+  const after = Date.now();
+  console.log(`Found ${featureTests.size} features ` +
+      `(took ${after - before} ms)`);
+
+  await lib.results.loadRunTrees(repo, alignedRuns);
+
+  // TODO: Score the runs. Each test in a run will be scored against the
+  // features it belongs to, and the per-feature scores aggregated per product,
+  // to be implemented after further discussion with the interop team.
+
+  // TODO: Write the scores to the file named by --output, defaulting to
+  // {stable, experimental}-feature-level-interop.csv, once the runs are scored.
+}
+
+main().catch(reason => {
+  console.error(reason);
+  process.exit(1);
+});


### PR DESCRIPTION
Adds feature-level-interop.js, based on browser-specific-failures.js, and a
build.sh function to run it. It loads the aligned runs and their result trees,
and reads the feature to test mapping from the WEB_FEATURES_MANIFEST.json.gz
asset on each web-platform-tests/wpt release.

The runs are not scored yet, so nothing calls the build.sh function and no CSV
is written. Scoring needs further discussion with the interop team, since
counting tests alone lets features with thousands of tests dominate.

