### PR TITLE
Extract shared result utilities into lib/result-trees.js

### DIFF
--- a/interop-scoring/main.js
+++ b/interop-scoring/main.js
@@ -286,7 +286,7 @@ function scoreRuns(runs, allTestsSet) {
     for (const run of runs) {
       // Sum of the integer 0-1000 scores for each test.
       let score = 0;
-      lib.results.walkTests(run.tree, (path, test, results) => {
+      lib.resultTrees.walkTests(run.tree, (path, test, results) => {
         const testname = path + '/' + test;
         if (!allTestsSet.has(testname)) {
           return;

--- a/lib/browser-specific.js
+++ b/lib/browser-specific.js
@@ -7,17 +7,18 @@
  * browser (aka browser-specific failures).
  */
 
-const TEST_PASS_STATUSES = ['PASS'];
-const TEST_FAIL_STATUSES = ['FAIL', 'ERROR', 'TIMEOUT', 'CRASH'];
-// An empty string has been seen for some tests; see
-// https://github.com/web-platform-tests/wpt/issues/22306
-const TEST_NEUTRAL_STATUSES = ['PRECONDITION_FAILED', 'SKIP', ''];
+const {
+  SUBTEST_FAIL_STATUSES,
+  SUBTEST_NEUTRAL_STATUSES,
+  SUBTEST_PASS_STATUSES,
+  TEST_FAIL_STATUSES,
+  TEST_NEUTRAL_STATUSES,
+  TEST_PASS_STATUSES,
+} = require('./result-trees');
+
 const KNOWN_TEST_STATUSES = TEST_PASS_STATUSES.concat(
     TEST_FAIL_STATUSES, TEST_NEUTRAL_STATUSES);
 
-const SUBTEST_PASS_STATUSES = ['PASS'];
-const SUBTEST_FAIL_STATUSES = ['FAIL', 'ERROR', 'TIMEOUT', 'NOTRUN'];
-const SUBTEST_NEUTRAL_STATUSES = ['PRECONDITION_FAILED', 'SKIP'];
 const KNOWN_SUBTEST_STATUSES = SUBTEST_PASS_STATUSES.concat(
     SUBTEST_FAIL_STATUSES, SUBTEST_NEUTRAL_STATUSES);
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,8 @@
 'use strict';
 
 const browserSpecific = require('./browser-specific');
+const resultTrees = require('./result-trees');
 const results = require('./results');
 const runs = require('./runs');
 
-module.exports = {browserSpecific, results, runs};
+module.exports = {browserSpecific, resultTrees, results, runs};

--- a/lib/result-trees.js
+++ b/lib/result-trees.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const TEST_PASS_STATUSES = ['PASS'];
+const TEST_FAIL_STATUSES = ['FAIL', 'ERROR', 'TIMEOUT', 'CRASH'];
+// An empty string has been seen for some tests; see
+// https://github.com/web-platform-tests/wpt/issues/22306
+const TEST_NEUTRAL_STATUSES = ['PRECONDITION_FAILED', 'SKIP', ''];
+
+const SUBTEST_PASS_STATUSES = ['PASS'];
+const SUBTEST_FAIL_STATUSES = ['FAIL', 'ERROR', 'TIMEOUT', 'NOTRUN'];
+const SUBTEST_NEUTRAL_STATUSES = ['PRECONDITION_FAILED', 'SKIP'];
+
+// Walks an input tree in depth-first order, calling the visitor function on
+// each test in the tree. The visitor function should be of the form:
+//   visitor(path, test_name, test_results)
+//
+// Where test_results is an object as described in the module documentation.
+function walkTests(tree, visitor, path='') {
+  for (const [dir, subtree] of Object.entries(tree.trees)) {
+    walkTests(subtree, visitor, `${path}/${dir}`);
+  }
+
+  for (const [name, results] of Object.entries(tree.tests)) {
+    visitor(path, name, results);
+  }
+}
+
+module.exports = {
+  SUBTEST_FAIL_STATUSES,
+  SUBTEST_NEUTRAL_STATUSES,
+  SUBTEST_PASS_STATUSES,
+  TEST_FAIL_STATUSES,
+  TEST_NEUTRAL_STATUSES,
+  TEST_PASS_STATUSES,
+  walkTests,
+};

--- a/lib/results.js
+++ b/lib/results.js
@@ -205,27 +205,11 @@ async function loadRunTrees(repo, alignedRuns) {
       `${after - before} ms`);
 }
 
-// Walks an input tree in depth-first order, calling the visitor function on
-// each test in the tree. The visitor function should be of the form:
-//   visitor(path, test_name, test_results)
-//
-// Where test_results is an object as described in the module documentation.
-function walkTests(tree, visitor, path='') {
-  for (const [dir, subtree] of Object.entries(tree.trees)) {
-    walkTests(subtree, visitor, `${path}/${dir}`);
-  }
-
-  for (const [name, results] of Object.entries(tree.tests)) {
-    visitor(path, name, results);
-  }
-}
-
 // treeCache, testCache exposed only for git-query.js to report memory stats.
 module.exports = {
   getGitTree,
   getLocalRunIds,
   loadRunTrees,
-  walkTests,
   treeCache,
   testCache,
 };


### PR DESCRIPTION
Moves the status lists from lib/browser-specific.js and walkTests from
lib/results.js, so we can reuse them for feature level interop.
