### PR TITLE
Move the test path split into lib/result-trees.js

### DIFF
--- a/git-write.js
+++ b/git-write.js
@@ -6,6 +6,7 @@ const fetch = require('node-fetch');
 const flags = require('flags');
 const moment = require('moment');
 const Git = require('nodegit');
+const resultTrees = require('./lib/result-trees');
 const runs = require('./lib/runs');
 
 flags.defineInteger('max-runs', 0, 'Write at most this many runs');
@@ -120,15 +121,8 @@ async function writeReportToGit(report, repo, commitMessage, tagName) {
       blobCache.set(json, blobId);
     }
 
-    const path = test.test;
-    // Complexity to handle /foo/bar/test.html?a/b, which can occur especially
-    // with variants. decodeURIComponent needs to be used when reading.
-    const queryStart = path.indexOf('?');
-    const lastSlash = path.lastIndexOf('/', queryStart >= 0 ? queryStart : path.length);
-    const dirname = path.substr(0, lastSlash);
-    const filename = encodeURIComponent(path.substr(lastSlash + 1));
-
-    const dirs = dirname.split('/').filter(d => d);
+    const {dirs, filename} =
+        resultTrees.splitTestPathEncodedName(test.test);
 
     const tree = await getTree(dirs);
     tree.builder.insert(`${filename}.json`, blobId, Git.TreeEntry.FILEMODE.BLOB);

--- a/lib/result-trees.js
+++ b/lib/result-trees.js
@@ -10,6 +10,28 @@ const SUBTEST_PASS_STATUSES = ['PASS'];
 const SUBTEST_FAIL_STATUSES = ['FAIL', 'ERROR', 'TIMEOUT', 'NOTRUN'];
 const SUBTEST_NEUTRAL_STATUSES = ['PRECONDITION_FAILED', 'SKIP'];
 
+function splitTestPath(path) {
+  // Complexity to handle /foo/bar/test.html?a/b, which can occur especially
+  // with variants. decodeURIComponent needs to be used when reading.
+  const queryStart = path.indexOf('?');
+  const lastSlash = path.lastIndexOf(
+      '/', queryStart >= 0 ? queryStart : path.length);
+  const dirName = path.substr(0, lastSlash);
+  const rawFileName = path.substr(lastSlash + 1);
+
+  const dirs = dirName.split('/').filter(d => d);
+
+  return {
+    dirs,
+    rawFileName,
+  };
+}
+
+function splitTestPathEncodedName(testPath) {
+  const {dirs, rawFileName} = splitTestPath(testPath);
+  return {dirs, filename: encodeURIComponent(rawFileName)};
+}
+
 // Walks an input tree in depth-first order, calling the visitor function on
 // each test in the tree. The visitor function should be of the form:
 //   visitor(path, test_name, test_results)
@@ -32,5 +54,7 @@ module.exports = {
   TEST_FAIL_STATUSES,
   TEST_NEUTRAL_STATUSES,
   TEST_PASS_STATUSES,
+  splitTestPath,
+  splitTestPathEncodedName,
   walkTests,
 };

--- a/test/result-trees.js
+++ b/test/result-trees.js
@@ -1,0 +1,64 @@
+'use strict';
+
+const assert = require('chai').assert;
+
+const resultTrees = require('../lib/result-trees');
+
+describe('result-trees.js', () => {
+  describe('splitTestPath', () => {
+    it('splits a nested path into its directories and name', () => {
+      assert.deepEqual(
+          resultTrees.splitTestPath('/css/css-grid/grid-001.html'),
+          {dirs: ['css', 'css-grid'], rawFileName: 'grid-001.html'});
+    });
+
+    it('gives no directories for a test at the root', () => {
+      assert.deepEqual(resultTrees.splitTestPath('/a.html'),
+          {dirs: [], rawFileName: 'a.html'});
+    });
+
+    it('keeps a query string in the name', () => {
+      assert.deepEqual(
+          resultTrees.splitTestPath('/webcodecs/full-cycle.any.html?vp8'),
+          {dirs: ['webcodecs'], rawFileName: 'full-cycle.any.html?vp8'});
+    });
+
+    it('keeps a slash inside a query string out of the directories', () => {
+      assert.deepEqual(resultTrees.splitTestPath('/foo/bar/test.html?a/b'),
+          {dirs: ['foo', 'bar'], rawFileName: 'test.html?a/b'});
+    });
+
+    it('keeps uppercase letters verbatim', () => {
+      assert.deepEqual(resultTrees.splitTestPath('/css/A.html?Q=1'),
+          {dirs: ['css'], rawFileName: 'A.html?Q=1'});
+    });
+  });
+
+  describe('splitTestPathEncodedName', () => {
+    it('percent-encodes the name', () => {
+      assert.deepEqual(
+          resultTrees.splitTestPathEncodedName('/webcodecs/x.any.html?vp8'),
+          {dirs: ['webcodecs'], filename: 'x.any.html%3Fvp8'});
+    });
+
+    it('encodes a slash inside a query string', () => {
+      assert.deepEqual(
+          resultTrees.splitTestPathEncodedName('/foo/bar/test.html?a/b'),
+          {dirs: ['foo', 'bar'], filename: 'test.html%3Fa%2Fb'});
+    });
+
+    it('leaves a name needing no encoding alone', () => {
+      assert.deepEqual(
+          resultTrees.splitTestPathEncodedName('/css/grid-001.html'),
+          {dirs: ['css'], filename: 'grid-001.html'});
+    });
+
+    it('decodes back to the name splitTestPath returns', () => {
+      const testPath = '/foo/bar/test.html?a/b';
+      const {filename} = resultTrees.splitTestPathEncodedName(testPath);
+
+      assert.equal(decodeURIComponent(filename),
+          resultTrees.splitTestPath(testPath).rawFileName);
+    });
+  });
+});


### PR DESCRIPTION
Moves the split out of git-write.js, which keeps its encoded name through the
splitTestPathEncodedName wrapper, so a reader can use the unencoded one.

