### PR TITLE
Add test lookup by path

### DIFF
--- a/lib/result-trees.js
+++ b/lib/result-trees.js
@@ -32,6 +32,22 @@ function splitTestPathEncodedName(testPath) {
   return {dirs, filename: encodeURIComponent(rawFileName)};
 }
 
+// Returns the results of |testPath| in |tree|, or undefined if the run has no
+// such test.
+function findTestResults(tree, testPath) {
+  const {dirs, rawFileName} = splitTestPath(testPath);
+
+  let node = tree;
+  for (const dir of dirs) {
+    node = node.trees[dir];
+    if (node === undefined) {
+      return undefined;
+    }
+  }
+
+  return node.tests[rawFileName];
+}
+
 // Walks an input tree in depth-first order, calling the visitor function on
 // each test in the tree. The visitor function should be of the form:
 //   visitor(path, test_name, test_results)
@@ -54,6 +70,7 @@ module.exports = {
   TEST_FAIL_STATUSES,
   TEST_NEUTRAL_STATUSES,
   TEST_PASS_STATUSES,
+  findTestResults,
   splitTestPath,
   splitTestPathEncodedName,
   walkTests,

--- a/test/result-trees.js
+++ b/test/result-trees.js
@@ -3,6 +3,7 @@
 const assert = require('chai').assert;
 
 const resultTrees = require('../lib/result-trees');
+const {TreeBuilder} = require('./lib/tree-builder');
 
 describe('result-trees.js', () => {
   describe('splitTestPath', () => {
@@ -59,6 +60,35 @@ describe('result-trees.js', () => {
 
       assert.equal(decodeURIComponent(filename),
           resultTrees.splitTestPath(testPath).rawFileName);
+    });
+  });
+
+  describe('findTestResults', () => {
+    const tree = new TreeBuilder()
+        .addTest('css/a.html', 'PASS')
+        .addTest('root.html', 'OK')
+        .build();
+
+    it('finds a test in a directory', () => {
+      assert.equal(resultTrees.findTestResults(tree, '/css/a.html').status,
+          'PASS');
+    });
+
+    it('finds a test at the root of the tree', () => {
+      assert.equal(resultTrees.findTestResults(tree, '/root.html').status,
+          'OK');
+    });
+
+    it('returns undefined for a test the run does not have', () => {
+      assert.isUndefined(resultTrees.findTestResults(tree, '/css/gone.html'));
+    });
+
+    it('returns undefined for a directory the run does not have', () => {
+      assert.isUndefined(resultTrees.findTestResults(tree, '/dom/a.html'));
+    });
+
+    it('does not match a path differing only in case', () => {
+      assert.isUndefined(resultTrees.findTestResults(tree, '/css/A.html'));
     });
   });
 });


### PR DESCRIPTION
Adds lib.resultTrees.findTestResults, which descends a run's tree using
splitTestPath so a caller can iterate the manifest instead of walking the tree.

