### PR TITLE
Add the feature level interop scoring skeleton

### DIFF
--- a/lib/feature-level-interop.js
+++ b/lib/feature-level-interop.js
@@ -1,0 +1,37 @@
+'use strict';
+
+/**
+ * Implements per-web-feature interoperability scoring (aka feature level
+ * interop).
+ */
+
+// Scores one test as the fraction of it that passed, in [0, 1].
+function scoreTestResults(results) {
+  throw new Error('scoreTestResults is not implemented');
+}
+
+// Scores one feature for each browser in |expectedBrowsers|, or undefined if no
+// run has any of its |tests|.
+function scoreFeature(runs, expectedBrowsers, tests) {
+  throw new Error('scoreFeature is not implemented');
+}
+
+// Scores every web feature in |featureTestMap| against |runs|.
+function scoreRuns(runs, expectedBrowsers, featureTestMap) {
+  const featureScores = new Map();
+
+  for (const [feature, tests] of featureTestMap) {
+    const scored = scoreFeature(runs, expectedBrowsers, tests);
+    if (scored !== undefined) {
+      featureScores.set(feature, scored);
+    }
+  }
+
+  return featureScores;
+}
+
+module.exports = {
+  scoreFeature,
+  scoreRuns,
+  scoreTestResults,
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,8 +1,11 @@
 'use strict';
 
 const browserSpecific = require('./browser-specific');
+const featureLevelInterop = require('./feature-level-interop');
 const resultTrees = require('./result-trees');
 const results = require('./results');
 const runs = require('./runs');
 
-module.exports = {browserSpecific, resultTrees, results, runs};
+module.exports = {
+  browserSpecific, featureLevelInterop, resultTrees, results, runs,
+};


### PR DESCRIPTION
Adds lib/feature-level-interop.js with scoreRuns wired up and the two functions
it calls left as stubs, so the flow can be reviewed before the arithmetic.

