### PR TITLE
Move TreeBuilder into a shared test helper

### DIFF
--- a/test/browser-specific.js
+++ b/test/browser-specific.js
@@ -4,78 +4,8 @@
 
 const assert = require('chai').assert;
 const browserSpecific = require('../lib/browser-specific');
+const {TreeBuilder, nextUniqueId} = require('./lib/tree-builder');
 
-function createEmptyTree() {
-  return {
-    trees: {},
-    tests: {},
-  };
-}
-
-let uniqueId = 0;
-
-class TreeBuilder {
-  constructor() {
-    this.root = createEmptyTree();
-  }
-
-  build() {
-    // Time to add all the unique ids.
-    function addUniqueIds(node) {
-      node.id = ++uniqueId;
-
-      for (const test of Object.values(node.tests)) {
-        test.id = ++uniqueId;
-      }
-      for (const tree of Object.values(node.trees)) {
-        addUniqueIds(tree);
-      }
-    }
-
-    addUniqueIds(this.root);
-    return this.root;
-  }
-
-  // Add a test with a given status to the tree. The path parameter is
-  // interpreted as a directory path and subtrees are created as necessary.
-  addTest(path, status) {
-    let currentNode = this.root;
-    const testParts = path.split('/');
-    for (let i = 0; i < testParts.length - 1; i++) {
-      const directoryName = testParts[i];
-      if (!(directoryName in currentNode.trees)) {
-        currentNode.trees[directoryName] = createEmptyTree();
-      }
-      currentNode = currentNode.trees[directoryName];
-    }
-
-    const testName = testParts[testParts.length - 1];
-    assert.doesNotHaveAnyKeys(
-        currentNode.tests, testName, `tree already has a test at ${path}`);
-    currentNode.tests[testName] = {status};
-
-    return this;
-  }
-
-  // Add a subtest with a given status to the tree. The test object must already
-  // have been created; a subtest array will be created if necessary.
-  addSubtest(testPath, subtest, status) {
-    let currentNode = this.root;
-    const testParts = testPath.split('/');
-    for (let i = 0; i < testParts.length - 1; i++) {
-      currentNode = currentNode.trees[testParts[i]];
-    }
-
-    const testName = testParts[testParts.length - 1];
-    const test = currentNode.tests[testName];
-    if (test.subtests === undefined) {
-      test.subtests = [];
-    }
-    test.subtests.push({name: subtest, status});
-
-    return this;
-  }
-}
 
 describe('browser-specific.js', () => {
   describe('Browser Validation', () => {
@@ -353,12 +283,12 @@ describe('browser-specific.js', () => {
       // statuses have the same ID.
       const PASS = {
         'status': 'PASS',
-        'id': ++uniqueId,
+        'id': nextUniqueId(),
       };
 
       const FAIL = {
         'status': 'FAIL',
-        'id': ++uniqueId,
+        'id': nextUniqueId(),
       };
 
       const chromeTree = {
@@ -366,7 +296,7 @@ describe('browser-specific.js', () => {
         'tests': {
           'block-end-aligned-abspos-with-overflow.html': PASS,
         },
-        'id': ++uniqueId,
+        'id': nextUniqueId(),
       };
 
       const firefoxTree = {
@@ -378,7 +308,7 @@ describe('browser-specific.js', () => {
           'block-002-wm-vrl-print.html': PASS,
           'block-end-aligned-abspos-with-overflow.html': FAIL,
         },
-        'id': ++uniqueId,
+        'id': nextUniqueId(),
       };
 
       const runs = [

--- a/test/lib/tree-builder.js
+++ b/test/lib/tree-builder.js
@@ -1,0 +1,83 @@
+'use strict';
+
+const assert = require('chai').assert;
+
+function createEmptyTree() {
+  return {
+    trees: {},
+    tests: {},
+  };
+}
+
+let uniqueId = 0;
+
+class TreeBuilder {
+  constructor() {
+    this.root = createEmptyTree();
+  }
+
+  build() {
+    // Time to add all the unique ids.
+    function addUniqueIds(node) {
+      node.id = ++uniqueId;
+
+      for (const test of Object.values(node.tests)) {
+        test.id = ++uniqueId;
+      }
+      for (const tree of Object.values(node.trees)) {
+        addUniqueIds(tree);
+      }
+    }
+
+    addUniqueIds(this.root);
+    return this.root;
+  }
+
+  // Add a test with a given status to the tree. The path parameter is
+  // interpreted as a directory path and subtrees are created as necessary.
+  addTest(path, status) {
+    let currentNode = this.root;
+    const testParts = path.split('/');
+    for (let i = 0; i < testParts.length - 1; i++) {
+      const directoryName = testParts[i];
+      if (!(directoryName in currentNode.trees)) {
+        currentNode.trees[directoryName] = createEmptyTree();
+      }
+      currentNode = currentNode.trees[directoryName];
+    }
+
+    const testName = testParts[testParts.length - 1];
+    assert.doesNotHaveAnyKeys(
+        currentNode.tests, testName, `tree already has a test at ${path}`);
+    currentNode.tests[testName] = {status};
+
+    return this;
+  }
+
+  // Add a subtest with a given status to the tree. The test object must already
+  // have been created; a subtest array will be created if necessary.
+  addSubtest(testPath, subtest, status) {
+    let currentNode = this.root;
+    const testParts = testPath.split('/');
+    for (let i = 0; i < testParts.length - 1; i++) {
+      currentNode = currentNode.trees[testParts[i]];
+    }
+
+    const testName = testParts[testParts.length - 1];
+    const test = currentNode.tests[testName];
+    if (test.subtests === undefined) {
+      test.subtests = [];
+    }
+    test.subtests.push({name: subtest, status});
+
+    return this;
+  }
+}
+
+// Mints the next id, for a test that hand-builds a tree rather than using
+// TreeBuilder. There must be one counter, or ids collide across fixtures.
+function nextUniqueId() {
+  return ++uniqueId;
+}
+
+module.exports = {TreeBuilder, nextUniqueId};


### PR DESCRIPTION
Moves the tree fixture builder out of test/browser-specific.js so that other
test files can use it, then lets it take web features manifest paths.
