### PR TITLE
Add per-test scoring to lib/result-trees.js

### DIFF
--- a/lib/feature-level-interop.js
+++ b/lib/feature-level-interop.js
@@ -5,11 +5,6 @@
  * interop).
  */
 
-// Scores one test as the fraction of it that passed, in [0, 1].
-function scoreTestResults(results) {
-  throw new Error('scoreTestResults is not implemented');
-}
-
 // Scores one feature for each browser in |expectedBrowsers|, or undefined if no
 // run has any of its |tests|.
 function scoreFeature(runs, expectedBrowsers, tests) {
@@ -33,5 +28,4 @@ function scoreRuns(runs, expectedBrowsers, featureTestMap) {
 module.exports = {
   scoreFeature,
   scoreRuns,
-  scoreTestResults,
 };

--- a/lib/result-trees.js
+++ b/lib/result-trees.js
@@ -10,6 +10,19 @@ const SUBTEST_PASS_STATUSES = ['PASS'];
 const SUBTEST_FAIL_STATUSES = ['FAIL', 'ERROR', 'TIMEOUT', 'NOTRUN'];
 const SUBTEST_NEUTRAL_STATUSES = ['PRECONDITION_FAILED', 'SKIP'];
 
+const KNOWN_TEST_STATUSES = new Set([
+  'OK', // A test with subtests.
+  ...TEST_PASS_STATUSES,
+  ...TEST_FAIL_STATUSES,
+  ...TEST_NEUTRAL_STATUSES,
+]);
+
+const KNOWN_SUBTEST_STATUSES = new Set([
+  ...SUBTEST_PASS_STATUSES,
+  ...SUBTEST_FAIL_STATUSES,
+  ...SUBTEST_NEUTRAL_STATUSES,
+]);
+
 function splitTestPath(path) {
   // Complexity to handle /foo/bar/test.html?a/b, which can occur especially
   // with variants. decodeURIComponent needs to be used when reading.
@@ -63,6 +76,36 @@ function walkTests(tree, visitor, path='') {
   }
 }
 
+// Scores one test as the fraction of it that passed, in [0, 1].
+function scoreTestResults(results) {
+  const status = results['status'];
+  if (!KNOWN_TEST_STATUSES.has(status)) {
+    throw new Error(`Unknown test status: '${status}'`);
+  }
+
+  if (!('subtests' in results)) {
+    return status === 'PASS' ? 1 : 0;
+  }
+
+  const subtests = results['subtests'];
+  if (subtests.length === 0) {
+    return 0;
+  }
+
+  let passes = 0;
+  for (const subtest of subtests) {
+    const subtestStatus = subtest['status'];
+    if (!KNOWN_SUBTEST_STATUSES.has(subtestStatus)) {
+      throw new Error(`Unknown subtest status for '${subtest['name']}': ` +
+          `'${subtestStatus}'`);
+    }
+    if (subtestStatus === 'PASS') {
+      passes += 1;
+    }
+  }
+  return passes / subtests.length;
+}
+
 module.exports = {
   SUBTEST_FAIL_STATUSES,
   SUBTEST_NEUTRAL_STATUSES,
@@ -71,6 +114,7 @@ module.exports = {
   TEST_NEUTRAL_STATUSES,
   TEST_PASS_STATUSES,
   findTestResults,
+  scoreTestResults,
   splitTestPath,
   splitTestPathEncodedName,
   walkTests,

--- a/test/result-trees.js
+++ b/test/result-trees.js
@@ -91,4 +91,95 @@ describe('result-trees.js', () => {
       assert.isUndefined(resultTrees.findTestResults(tree, '/css/A.html'));
     });
   });
+
+  describe('scoreTestResults', () => {
+    it('scores a reftest that passed as one and one that timed out as zero',
+        () => {
+          assert.equal(
+              resultTrees.scoreTestResults({status: 'PASS'}), 1);
+          assert.equal(
+              resultTrees.scoreTestResults({status: 'TIMEOUT'}), 0);
+        });
+
+    it('scores a test with subtests as the fraction that passed', () => {
+      const results = {status: 'OK', subtests: [
+        {name: 'test 1', status: 'PASS'},
+        {name: 'test 2', status: 'PASS'},
+        {name: 'test 3', status: 'FAIL'},
+        {name: 'test 4', status: 'FAIL'},
+      ]};
+
+      assert.equal(resultTrees.scoreTestResults(results), 0.5);
+    });
+
+    it('ignores the harness status when the test has subtests', () => {
+      const results = {status: 'ERROR', subtests: [
+        {name: 'test 1', status: 'PASS'},
+        {name: 'test 2', status: 'FAIL'},
+      ]};
+
+      assert.equal(resultTrees.scoreTestResults(results), 0.5);
+    });
+
+    it('scores a test reporting an empty subtests array as zero', () => {
+      assert.equal(resultTrees.scoreTestResults(
+          {status: 'OK', subtests: []}), 0);
+    });
+
+    it('scores a test whose harness reported OK with no subtests as zero',
+        () => {
+          assert.equal(resultTrees.scoreTestResults({status: 'OK'}), 0);
+        });
+
+    it('counts duplicate subtest names once each, as the run reported them',
+        () => {
+          const results = {status: 'OK', subtests: [
+            {name: 'test 1', status: 'PASS'},
+            {name: 'test 1', status: 'FAIL'},
+          ]};
+
+          assert.equal(resultTrees.scoreTestResults(results), 0.5);
+        });
+
+    it('counts NOTRUN, SKIP and PRECONDITION_FAILED subtests as failures',
+        () => {
+          const results = {status: 'OK', subtests: [
+            {name: 'test 1', status: 'PASS'},
+            {name: 'test 2', status: 'NOTRUN'},
+            {name: 'test 3', status: 'SKIP'},
+            {name: 'test 4', status: 'PRECONDITION_FAILED'},
+          ]};
+
+          assert.equal(resultTrees.scoreTestResults(results), 0.25);
+        });
+
+    it('counts a top-level SKIP as a failure', () => {
+      assert.equal(resultTrees.scoreTestResults({status: 'SKIP'}), 0);
+    });
+
+    it('scores a test that timed out after its one passing subtest as a full ' +
+        'pass', () => {
+      // The harness died early, so the browser is credited with the single
+      // subtest it managed to report; see the note on scoreTestResults.
+      const results = {status: 'TIMEOUT', subtests: [
+        {name: 'test 1', status: 'PASS'},
+      ]};
+
+      assert.equal(resultTrees.scoreTestResults(results), 1);
+    });
+
+    it('throws for a test status it does not know', () => {
+      assert.throws(() => {
+        resultTrees.scoreTestResults({status: 'FOO'});
+      }, /Unknown test status: 'FOO'/);
+    });
+
+    it('throws for a subtest status it does not know', () => {
+      assert.throws(() => {
+        resultTrees.scoreTestResults({status: 'OK', subtests: [
+          {name: 'test 1', status: 'FOO'},
+        ]});
+      }, /Unknown subtest status for 'test 1': 'FOO'/);
+    });
+  });
 });


### PR DESCRIPTION
Scores a test as the fraction of its subtests that passed.

