### PR TITLE
Average feature scores and fetch a pinned manifest

### DIFF
--- a/lib/feature-level-interop.js
+++ b/lib/feature-level-interop.js
@@ -54,6 +54,37 @@ function scoreFeature(runs, expectedBrowsers, tests) {
   };
 }
 
+// Averages the per-feature scores in |featureScores|, weighting every feature
+// equally however many tests it has, or undefined if no feature was scored. A
+// date with nothing to score is a date to skip, as it is for scoreFeature.
+function averageFeatureScores(featureScores, expectedBrowsers) {
+  if (featureScores.size === 0) {
+    return undefined;
+  }
+
+  const totals = new Map(expectedBrowsers.map(product => [product, 0]));
+  let interop = 0;
+
+  for (const scored of featureScores.values()) {
+    for (const product of expectedBrowsers) {
+      // Averaging a product the feature was not scored for would reach the CSV
+      // as a literal NaN rather than failing the run.
+      if (!scored.scores.has(product)) {
+        throw new Error(`A feature was not scored for '${product}'`);
+      }
+      totals.set(product, totals.get(product) + scored.scores.get(product));
+    }
+    interop += scored.interop;
+  }
+
+  return {
+    scores: new Map(expectedBrowsers.map(
+        product => [product, totals.get(product) / featureScores.size])),
+    interop: interop / featureScores.size,
+    features: featureScores.size,
+  };
+}
+
 // Scores every web feature in |featureTestMap| against |runs|.
 function scoreRuns(runs, expectedBrowsers, featureTestMap) {
   const featureScores = new Map();
@@ -69,6 +100,7 @@ function scoreRuns(runs, expectedBrowsers, featureTestMap) {
 }
 
 module.exports = {
+  averageFeatureScores,
   scoreFeature,
   scoreRuns,
 };

--- a/lib/runs.js
+++ b/lib/runs.js
@@ -14,7 +14,7 @@ const RUNS_API = 'https://wpt.fyi/api/runs';
 // built from, so we match on the label, which does not change; wpt.fyi does the
 // same in shared/web_features_manifest_github_download.go.
 const WPT_RELEASE_API =
-    'https://api.github.com/repos/web-platform-tests/wpt/releases/latest';
+    'https://api.github.com/repos/web-platform-tests/wpt/releases';
 const WEB_FEATURES_MANIFEST_LABEL = 'WEB_FEATURES_MANIFEST.json.gz';
 
 function apiURL(options = {}) {
@@ -200,13 +200,13 @@ function parseWebFeaturesManifest(buffer) {
   return featureTests;
 }
 
-// Fetches the web features manifest from the latest wpt release and returns a
-// map from feature to the set of tests that make up that feature.
-async function fetchWebFeaturesManifest() {
-  const releaseResponse = await fetch(WPT_RELEASE_API);
+// Fetches the web features manifest at |releaseURL| and
+// returns a map from feature to the set of tests that make up that feature.
+async function fetchWebFeaturesManifestFromURL(releaseURL) {
+  const releaseResponse = await fetch(releaseURL);
   if (!releaseResponse.ok) {
     throw new Error(`non-OK fetch status ${releaseResponse.status} when ` +
-        `fetching ${WPT_RELEASE_API}`);
+        `fetching ${releaseURL}`);
   }
   const asset = findWebFeaturesManifestAsset(await releaseResponse.json());
 
@@ -218,12 +218,27 @@ async function fetchWebFeaturesManifest() {
   return parseWebFeaturesManifest(await assetResponse.buffer());
 }
 
+// Fetches the web features manifest from the latest wpt release and returns a
+// map from feature to the set of tests that make up that feature.
+async function fetchWebFeaturesManifest() {
+  return fetchWebFeaturesManifestFromURL(`${WPT_RELEASE_API}/latest`);
+}
+
+// Fetches the web features manifest from the wpt release tagged |tag|. The
+// caller pins the tag so that a score does not change between builds, which
+// makes a release without the manifest a broken pin rather than a date to skip.
+async function fetchWebFeaturesManifestFromRelease(tag) {
+  return fetchWebFeaturesManifestFromURL(
+      `${WPT_RELEASE_API}/tags/${tag}`);
+}
+
 module.exports = {
   get,
   getAll,
   getIterator,
   fetchAlignedRunsFromServer,
   fetchWebFeaturesManifest,
+  fetchWebFeaturesManifestFromRelease,
   findWebFeaturesManifestAsset,
   parseWebFeaturesManifest,
 };

--- a/test/feature-level-interop.js
+++ b/test/feature-level-interop.js
@@ -5,7 +5,12 @@ const assert = require('chai').assert;
 const featureLevelInterop = require('../lib/feature-level-interop');
 const {TreeBuilder} = require('./lib/tree-builder');
 
-// Builds the map that lib.runs.fetchWebFeaturesManifest returns.
+// The products feature-level-interop.js scores by default. Two browsers cannot
+// tell a minimum taken across every product from one taken over a pair, so the
+// fixtures use all three.
+const expectedBrowsers = ['chrome', 'firefox', 'safari'];
+
+// Builds the map that lib.runs.parseWebFeaturesManifest returns.
 function createFeatureTests(featureToTests) {
   return new Map(Object.entries(featureToTests).map(
       ([feature, tests]) => [feature, new Set(tests)]));
@@ -19,8 +24,6 @@ function createRuns(browserToTree) {
 
 describe('feature-level-interop.js', () => {
   describe('scoreFeature', () => {
-    const expectedBrowsers = ['chrome', 'firefox'];
-
     it('scores each product as its fraction of the feature passed', () => {
       const runs = createRuns({
         chrome: new TreeBuilder()
@@ -31,42 +34,90 @@ describe('feature-level-interop.js', () => {
             .addTest('css/a.html', 'PASS')
             .addTest('css/b.html', 'FAIL')
             .build(),
+        safari: new TreeBuilder()
+            .addTest('css/a.html', 'FAIL')
+            .addTest('css/b.html', 'FAIL')
+            .build(),
       });
 
       const scored = featureLevelInterop.scoreFeature(
           runs, expectedBrowsers, new Set(['/css/a.html', '/css/b.html']));
 
       assert.deepEqual(scored.scores,
-          new Map([['chrome', 1], ['firefox', 0.5]]));
-      assert.equal(scored.interop, 0.5);
+          new Map([['chrome', 1], ['firefox', 0.5], ['safari', 0]]));
       assert.equal(scored.tests, 2);
     });
 
-    it('scores each product passing only what the other fails as zero interop',
-        () => {
-          const runs = createRuns({
-            chrome: new TreeBuilder()
-                .addTest('css/a.html', 'PASS')
-                .addTest('css/b.html', 'FAIL')
-                .build(),
-            firefox: new TreeBuilder()
-                .addTest('css/a.html', 'FAIL')
-                .addTest('css/b.html', 'PASS')
-                .build(),
-          });
+    it('takes the lowest score among every product, not just two', () => {
+      // Safari is the lowest on c and d but not on e, which firefox fails, so
+      // dropping either of them from the minimum changes the interop score.
+      const runs = createRuns({
+        chrome: new TreeBuilder()
+            .addTest('css/a.html', 'PASS')
+            .addTest('css/b.html', 'PASS')
+            .addTest('css/c.html', 'PASS')
+            .addTest('css/d.html', 'PASS')
+            .addTest('css/e.html', 'PASS')
+            .build(),
+        firefox: new TreeBuilder()
+            .addTest('css/a.html', 'PASS')
+            .addTest('css/b.html', 'PASS')
+            .addTest('css/c.html', 'PASS')
+            .addTest('css/d.html', 'PASS')
+            .addTest('css/e.html', 'FAIL')
+            .build(),
+        safari: new TreeBuilder()
+            .addTest('css/a.html', 'PASS')
+            .addTest('css/b.html', 'PASS')
+            .addTest('css/c.html', 'FAIL')
+            .addTest('css/d.html', 'FAIL')
+            .addTest('css/e.html', 'PASS')
+            .build(),
+      });
 
-          const scored = featureLevelInterop.scoreFeature(
-              runs, expectedBrowsers, new Set(['/css/a.html', '/css/b.html']));
+      const scored = featureLevelInterop.scoreFeature(runs, expectedBrowsers,
+          new Set(['/css/a.html', '/css/b.html', '/css/c.html',
+            '/css/d.html', '/css/e.html']));
 
-          // The lowest per-browser mean would be 0.5; the mean of the per-test
-          // minima is 0, because neither test passes everywhere.
-          assert.equal(scored.interop, 0);
-        });
+      assert.deepEqual(scored.scores,
+          new Map([['chrome', 1], ['firefox', 0.8], ['safari', 0.6]]));
+      // Only a and b pass everywhere. Ignoring safari would give 0.8, and the
+      // lowest per-product mean would be 0.6.
+      assert.equal(scored.interop, 0.4);
+    });
+
+    it('scores zero interop when no test passes in every product', () => {
+      const runs = createRuns({
+        chrome: new TreeBuilder()
+            .addTest('css/a.html', 'PASS')
+            .addTest('css/b.html', 'FAIL')
+            .addTest('css/c.html', 'FAIL')
+            .build(),
+        firefox: new TreeBuilder()
+            .addTest('css/a.html', 'FAIL')
+            .addTest('css/b.html', 'PASS')
+            .addTest('css/c.html', 'FAIL')
+            .build(),
+        safari: new TreeBuilder()
+            .addTest('css/a.html', 'FAIL')
+            .addTest('css/b.html', 'FAIL')
+            .addTest('css/c.html', 'PASS')
+            .build(),
+      });
+
+      const scored = featureLevelInterop.scoreFeature(runs, expectedBrowsers,
+          new Set(['/css/a.html', '/css/b.html', '/css/c.html']));
+
+      // The lowest per-product mean would be 1/3; the mean of the per-test
+      // minima is 0, because no test passes everywhere.
+      assert.equal(scored.interop, 0);
+    });
 
     it('divides by the tests found rather than the tests listed', () => {
       const runs = createRuns({
         chrome: new TreeBuilder().addTest('css/a.html', 'PASS').build(),
         firefox: new TreeBuilder().addTest('css/a.html', 'PASS').build(),
+        safari: new TreeBuilder().addTest('css/a.html', 'PASS').build(),
       });
 
       const scored = featureLevelInterop.scoreFeature(
@@ -74,7 +125,7 @@ describe('feature-level-interop.js', () => {
 
       assert.equal(scored.tests, 1);
       assert.deepEqual(scored.scores,
-          new Map([['chrome', 1], ['firefox', 1]]));
+          new Map([['chrome', 1], ['firefox', 1], ['safari', 1]]));
     });
 
     it('scores a product zero for a test only another product has', () => {
@@ -84,6 +135,7 @@ describe('feature-level-interop.js', () => {
             .addTest('css/b.html', 'PASS')
             .build(),
         firefox: new TreeBuilder().addTest('css/a.html', 'PASS').build(),
+        safari: new TreeBuilder().addTest('css/a.html', 'PASS').build(),
       });
 
       const scored = featureLevelInterop.scoreFeature(
@@ -91,7 +143,7 @@ describe('feature-level-interop.js', () => {
 
       assert.equal(scored.tests, 2);
       assert.deepEqual(scored.scores,
-          new Map([['chrome', 1], ['firefox', 0.5]]));
+          new Map([['chrome', 1], ['firefox', 0.5], ['safari', 0.5]]));
       assert.equal(scored.interop, 0.5);
     });
 
@@ -99,6 +151,7 @@ describe('feature-level-interop.js', () => {
       const runs = createRuns({
         chrome: new TreeBuilder().addTest('css/a.html', 'PASS').build(),
         firefox: new TreeBuilder().addTest('css/a.html', 'PASS').build(),
+        safari: new TreeBuilder().addTest('css/a.html', 'PASS').build(),
       });
 
       assert.isUndefined(featureLevelInterop.scoreFeature(
@@ -111,24 +164,157 @@ describe('feature-level-interop.js', () => {
             .addTest('css/a.html', 'OK')
             .addSubtest('css/a.html', 'one', 'PASS')
             .addSubtest('css/a.html', 'two', 'PASS')
+            .addSubtest('css/a.html', 'three', 'PASS')
+            .addSubtest('css/a.html', 'four', 'PASS')
             .build(),
         firefox: new TreeBuilder()
             .addTest('css/a.html', 'OK')
             .addSubtest('css/a.html', 'one', 'PASS')
-            .addSubtest('css/a.html', 'two', 'FAIL')
+            .addSubtest('css/a.html', 'two', 'PASS')
+            .addSubtest('css/a.html', 'three', 'PASS')
+            .addSubtest('css/a.html', 'four', 'FAIL')
+            .build(),
+        safari: new TreeBuilder()
+            .addTest('css/a.html', 'OK')
+            .addSubtest('css/a.html', 'one', 'PASS')
+            .addSubtest('css/a.html', 'two', 'PASS')
+            .addSubtest('css/a.html', 'three', 'FAIL')
+            .addSubtest('css/a.html', 'four', 'FAIL')
             .build(),
       });
 
       const scored = featureLevelInterop.scoreFeature(
           runs, expectedBrowsers, new Set(['/css/a.html']));
 
+      // The fractions are 1, 0.75 and 0.5, so ignoring safari would give 0.75.
       assert.equal(scored.interop, 0.5);
     });
   });
 
-  describe('scoreRuns', () => {
-    const expectedBrowsers = ['chrome', 'firefox'];
+  describe('averageFeatureScores', () => {
+    it('weights a two test feature the same as a one test feature', () => {
+      const runs = createRuns({
+        chrome: new TreeBuilder()
+            .addTest('css/a.html', 'PASS')
+            .addTest('css/b.html', 'PASS')
+            .addTest('dom/c.html', 'PASS')
+            .build(),
+        firefox: new TreeBuilder()
+            .addTest('css/a.html', 'PASS')
+            .addTest('css/b.html', 'FAIL')
+            .addTest('dom/c.html', 'PASS')
+            .build(),
+        safari: new TreeBuilder()
+            .addTest('css/a.html', 'PASS')
+            .addTest('css/b.html', 'FAIL')
+            .addTest('dom/c.html', 'FAIL')
+            .build(),
+      });
 
+      const featureScores = featureLevelInterop.scoreRuns(
+          runs, expectedBrowsers, createFeatureTests({
+            grid: ['/css/a.html', '/css/b.html'],
+            audio: ['/dom/c.html'],
+          }));
+      const averaged = featureLevelInterop.averageFeatureScores(
+          featureScores, expectedBrowsers);
+
+      // grid scores 1, 0.5 and 0.5; audio scores 1, 1 and 0. Weighting the
+      // features by their test counts would give firefox 2/3 and safari 1/3.
+      assert.deepEqual(averaged.scores,
+          new Map([['chrome', 1], ['firefox', 0.75], ['safari', 0.25]]));
+      assert.equal(averaged.features, 2);
+    });
+
+    it('averages each feature interop rather than taking the lowest browser',
+        () => {
+          const runs = createRuns({
+            chrome: new TreeBuilder()
+                .addTest('css/a.html', 'PASS')
+                .addTest('css/b.html', 'FAIL')
+                .addTest('dom/c.html', 'PASS')
+                .build(),
+            firefox: new TreeBuilder()
+                .addTest('css/a.html', 'FAIL')
+                .addTest('css/b.html', 'PASS')
+                .addTest('dom/c.html', 'PASS')
+                .build(),
+            safari: new TreeBuilder()
+                .addTest('css/a.html', 'PASS')
+                .addTest('css/b.html', 'PASS')
+                .addTest('dom/c.html', 'PASS')
+                .build(),
+          });
+
+          const featureScores = featureLevelInterop.scoreRuns(
+              runs, expectedBrowsers, createFeatureTests({
+                grid: ['/css/a.html', '/css/b.html'],
+                audio: ['/dom/c.html'],
+              }));
+          const averaged = featureLevelInterop.averageFeatureScores(
+              featureScores, expectedBrowsers);
+
+          // grid has no test that passes everywhere, so it scores zero interop
+          // while chrome and firefox average 0.5 on it; audio scores one. The
+          // lowest per-product mean would be 0.75 rather than 0.5.
+          assert.deepEqual(averaged.scores, new Map(
+              [['chrome', 0.75], ['firefox', 0.75], ['safari', 1]]));
+          assert.equal(averaged.interop, 0.5);
+        });
+
+    it('counts the features scored rather than the features listed', () => {
+      const runs = createRuns({
+        chrome: new TreeBuilder().addTest('css/a.html', 'PASS').build(),
+        firefox: new TreeBuilder().addTest('css/a.html', 'PASS').build(),
+        safari: new TreeBuilder().addTest('css/a.html', 'PASS').build(),
+      });
+
+      const featureScores = featureLevelInterop.scoreRuns(
+          runs, expectedBrowsers, createFeatureTests({
+            grid: ['/css/a.html'],
+            audio: ['/dom/gone.html'],
+          }));
+      const averaged = featureLevelInterop.averageFeatureScores(
+          featureScores, expectedBrowsers);
+
+      // Averaging over the listed features instead would halve every score.
+      assert.equal(averaged.features, 1);
+      assert.deepEqual(averaged.scores,
+          new Map([['chrome', 1], ['firefox', 1], ['safari', 1]]));
+      assert.equal(averaged.interop, 1);
+    });
+
+    it('returns undefined when no feature was scored', () => {
+      const runs = createRuns({
+        chrome: new TreeBuilder().addTest('css/a.html', 'PASS').build(),
+        firefox: new TreeBuilder().addTest('css/a.html', 'PASS').build(),
+        safari: new TreeBuilder().addTest('css/a.html', 'PASS').build(),
+      });
+
+      const featureScores = featureLevelInterop.scoreRuns(runs,
+          expectedBrowsers, createFeatureTests({audio: ['/dom/gone.html']}));
+      assert.equal(featureScores.size, 0);
+
+      assert.isUndefined(featureLevelInterop.averageFeatureScores(
+          featureScores, expectedBrowsers));
+    });
+
+    it('throws for a product a feature was not scored for', () => {
+      // Averaging the missing product would reach the CSV as a literal NaN.
+      const featureScores = new Map([['grid', {
+        scores: new Map([['chrome', 1]]),
+        interop: 1,
+        tests: 1,
+      }]]);
+
+      assert.throws(() => {
+        featureLevelInterop.averageFeatureScores(
+            featureScores, expectedBrowsers);
+      }, /A feature was not scored for 'firefox'/);
+    });
+  });
+
+  describe('scoreRuns', () => {
     it('scores every feature the manifest lists', () => {
       const runs = createRuns({
         chrome: new TreeBuilder()
@@ -136,6 +322,10 @@ describe('feature-level-interop.js', () => {
             .addTest('x.html', 'FAIL')
             .build(),
         firefox: new TreeBuilder()
+            .addTest('css/a.html', 'PASS')
+            .addTest('x.html', 'FAIL')
+            .build(),
+        safari: new TreeBuilder()
             .addTest('css/a.html', 'PASS')
             .addTest('x.html', 'FAIL')
             .build(),
@@ -153,6 +343,7 @@ describe('feature-level-interop.js', () => {
       const runs = createRuns({
         chrome: new TreeBuilder().addTest('css/a.html', 'PASS').build(),
         firefox: new TreeBuilder().addTest('css/a.html', 'PASS').build(),
+        safari: new TreeBuilder().addTest('css/a.html', 'PASS').build(),
       });
 
       const scored = featureLevelInterop.scoreRuns(runs, expectedBrowsers,
@@ -165,6 +356,7 @@ describe('feature-level-interop.js', () => {
       const runs = createRuns({
         chrome: new TreeBuilder().addTest('css/a.html', 'PASS').build(),
         firefox: new TreeBuilder().addTest('css/a.html', 'FAIL').build(),
+        safari: new TreeBuilder().addTest('css/a.html', 'PASS').build(),
       });
 
       const scored = featureLevelInterop.scoreRuns(

--- a/test/runs.js
+++ b/test/runs.js
@@ -69,6 +69,28 @@ describe('runs.js', () => {
         runs.findWebFeaturesManifestAsset(release);
       }, /No WEB_FEATURES_MANIFEST\.json\.gz asset on merge_pr_12345/);
     });
+
+    it('should pick the gzip asset among the compressions published', () => {
+      // Every manifest is published as .bz2, .gz and .zst, so matching on a
+      // name or label prefix would take whichever came first, and only the
+      // gzip one is what parseWebFeaturesManifest can gunzip. Asset list seen
+      // on merge_pr_62355 with:
+      //   gh api repos/web-platform-tests/wpt/releases/tags/merge_pr_62355
+      const gzip = createAsset(
+          'WEB_FEATURES_MANIFEST-abcdef.json.gz', MANIFEST_LABEL);
+      const release = createRelease([
+        createAsset('MANIFEST-abcdef.json.bz2', 'MANIFEST.json.bz2'),
+        createAsset('MANIFEST-abcdef.json.gz', 'MANIFEST.json.gz'),
+        createAsset('MANIFEST-abcdef.json.zst', 'MANIFEST.json.zst'),
+        createAsset('WEB_FEATURES_MANIFEST-abcdef.json.bz2',
+            'WEB_FEATURES_MANIFEST.json.bz2'),
+        gzip,
+        createAsset('WEB_FEATURES_MANIFEST-abcdef.json.zst',
+            'WEB_FEATURES_MANIFEST.json.zst'),
+      ]);
+
+      assert.strictEqual(runs.findWebFeaturesManifestAsset(release), gzip);
+    });
   });
 
   describe('parseWebFeaturesManifest', () => {


### PR DESCRIPTION
This PR adds the logic for aggregating per-feature interop scores via
averageFeatureScores in feature-level-interop.js. This PR also adds
fetchWebFeaturesManifestFromRelease to fetch historical web feature tags
that we will be able to map to corresponding wpt runs to meaningfully
backdate scores.
