### PR TITLE
Score every date and write the feature-level interop CSVs

### DIFF
--- a/feature-level-interop.js
+++ b/feature-level-interop.js
@@ -3,28 +3,50 @@
 /**
  * Implements a view of web interoperability per web feature over time.
  *
- * This is currently just the framework: the aligned runs, their result trees
- * and the feature to test mapping are all loaded, but the runs are not scored
- * yet.
+ * Each date is scored against the web features manifest built from that date's
+ * own wpt revision, so a score is never a run measured against a catalogue it
+ * did not run from. Every date in range is scored on every run, as
+ * browser-specific-failures.js does.
  */
 
 const flags = require('flags');
+const fs = require('fs');
 const Git = require('nodegit');
 const lib = require('./lib');
 const moment = require('moment');
 
-flags.defineString('from', '2018-07-01', 'Starting date (inclusive)');
+flags.defineString('from', '2026-01-28', 'Starting date (inclusive)');
 flags.defineString('to', moment().format('YYYY-MM-DD'),
     'Ending date (exclusive)');
 flags.defineStringList('products', ['chrome', 'firefox', 'safari'],
     'Browsers to compare. Must match the products used on wpt.fyi');
-flags.defineString('output', null,
-    'Output CSV file to write to. Defaults to ' +
-    '{stable, experimental}-feature-level-interop.csv');
 flags.defineBoolean('experimental', false,
     'Calculate metrics for experimental runs.');
 flags.parse();
 
+// The earliest date whose wpt release carries a web features manifest. Dates
+// before it cannot be scored at all, so we refuse them rather than skip them.
+const EARLIEST_MANIFEST_DATE = '2024-01-20';
+
+
+// Every CSV lands here, which is the directory build.sh deploys to gh-pages.
+const OUTPUT_DIR = 'out/data';
+
+// The name wpt.fyi fetches from gh-pages/data, so it is the one thing the two
+// repositories have to agree on.
+const CSV_NAME = 'browser-feature-interop';
+
+// Names the aggregate CSV for |channel|, which holds one row per date, each
+// averaged over every feature scored that day.
+function aggregateFilename(channel) {
+  return `${OUTPUT_DIR}/${channel}-${CSV_NAME}.csv`;
+}
+
+// Names the detail file for one |date| of |channel|, which holds one row per
+// feature.
+function detailFilename(channel, date) {
+  return `${OUTPUT_DIR}/${channel}-${CSV_NAME}-${date}.csv`;
+}
 
 async function main() {
   // Sort the products so that output files are consistent.
@@ -40,27 +62,77 @@ async function main() {
   // interested in.
   const from = moment(flags.get('from'));
   const to = moment(flags.get('to'));
+  if (from.isBefore(EARLIEST_MANIFEST_DATE)) {
+    throw new Error(`--from must not be before ${EARLIEST_MANIFEST_DATE}, ` +
+        'as no earlier wpt release has a web features manifest');
+  }
   const experimental = flags.get('experimental');
+
+  const channel = experimental ? 'experimental' : 'stable';
+  const aggregateFile = aggregateFilename(channel);
+  await fs.promises.mkdir(OUTPUT_DIR, {recursive: true});
+
   const alignedRuns = await lib.runs.fetchAlignedRunsFromServer(
       products, from, to, experimental);
 
-  // Work out which tests make up each web feature. This is done before the
-  // trees are loaded, so that a failure here does not throw away that work.
-  console.log('Fetching the web features manifest');
-  const before = Date.now();
-  const featureTests = await lib.runs.fetchWebFeaturesManifest();
-  const after = Date.now();
-  console.log(`Found ${featureTests.size} features ` +
-      `(took ${after - before} ms)`);
+  // Map every wpt revision to its release, which is how each date's own
+  // manifest is found. This is done before the trees are loaded, so that a
+  // failure here does not throw away that work.
+  console.log('Fetching the wpt release tags');
+  const tagMap = await lib.runs.fetchWptTagMap();
+  console.log(`Found ${tagMap.size} releases`);
 
   await lib.results.loadRunTrees(repo, alignedRuns);
 
-  // TODO: Score the runs. Each test in a run will be scored against the
-  // features it belongs to, and the per-feature scores aggregated per product,
-  // to be implemented after further discussion with the interop team.
+  // We're ready to score the runs now!
+  console.log('Calculating feature level interop for the runs');
+  const before = Date.now();
+  const dateToScores = new Map();
+  for (const [date, runs] of alignedRuns.entries()) {
+    // The SHA should be the same for all runs, so just grab the first.
+    const sha = runs[0].full_revision_hash;
+    const versions = new Map(
+        runs.map(run => [run.browser_name, run.browser_version]));
+    try {
+      const featureTests =
+          await lib.runs.fetchWebFeaturesManifestForRevision(sha, tagMap);
+      if (featureTests === undefined) {
+        console.log(`Skipping ${date}, no wpt release is tagged at ${sha}`);
+        continue;
+      }
 
-  // TODO: Write the scores to the file named by --output, defaulting to
-  // {stable, experimental}-feature-level-interop.csv, once the runs are scored.
+      const featureScores =
+          lib.featureLevelInterop.scoreRuns(runs, products, featureTests);
+      const averaged = lib.featureLevelInterop.averageFeatureScores(
+          featureScores, products);
+      if (averaged === undefined) {
+        console.log(`Skipping ${date}, no run has any test of any feature`);
+        continue;
+      }
+
+      await fs.promises.writeFile(detailFilename(channel, date),
+          lib.interopCsv.formatDetailCsv(products, featureScores), 'utf-8');
+
+      dateToScores.set(date, {
+        sha,
+        manifest: tagMap.get(sha),
+        versions,
+        scores: averaged.scores,
+        interop: averaged.interop,
+      });
+    } catch (e) {
+      e.message += `\n\tRuns: ${runs.map(r => r.id)}`;
+      throw e;
+    }
+  }
+  const after = Date.now();
+  console.log(`Done scoring (took ${after - before} ms)`);
+
+  // Finally, time to dump stuff.
+  console.log(`Writing data to ${aggregateFile}`);
+  await fs.promises.writeFile(aggregateFile,
+      lib.interopCsv.formatAggregateCsv(products, dateToScores),
+      'utf-8');
 }
 
 main().catch(reason => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,10 +2,11 @@
 
 const browserSpecific = require('./browser-specific');
 const featureLevelInterop = require('./feature-level-interop');
+const interopCsv = require('./interop-csv');
 const resultTrees = require('./result-trees');
 const results = require('./results');
 const runs = require('./runs');
 
 module.exports = {
-  browserSpecific, featureLevelInterop, resultTrees, results, runs,
+  browserSpecific, featureLevelInterop, interopCsv, resultTrees, results, runs,
 };

--- a/lib/interop-csv.js
+++ b/lib/interop-csv.js
@@ -1,0 +1,89 @@
+'use strict';
+
+/**
+ * Formats the CSVs that feature-level-interop.js publishes: a trendline row per
+ * date, and a feature breakdown per date.
+ */
+
+// Formats a score in [0, 1] as the percentage with one decimal that the
+// dashboard reads.
+function formatScore(score) {
+  return (score * 100).toFixed(1);
+}
+
+// Quotes |value| if it holds anything that would otherwise add a column or a
+// row. Browser versions are the field that can, as wpt.fyi reports them
+// verbatim from the run.
+function csvField(value) {
+  const field = String(value);
+  if (/[",\r\n]/.test(field)) {
+    return `"${field.replace(/"/g, '""')}"`;
+  }
+  return field;
+}
+
+// Returns the aggregate CSV for |dateToScores|, keyed by date, which holds one
+// row per date scored.
+function formatAggregateCsv(products, dateToScores) {
+  let data = 'sha,date,manifest';
+  for (const product of products) {
+    data += `,${product}-version,${product}`;
+  }
+  data += ',interop\n';
+
+  // ES6 maps iterate in insertion order, and we initially inserted in date
+  // order, so we can just iterate |dateToScores|.
+  for (const [date, scored] of dateToScores) {
+    const csvRecord = [
+      csvField(scored.sha),
+      csvField(date),
+      csvField(scored.manifest),
+    ];
+    // Both halves of a product's pair are looked up by name. wpt.fyi happens to
+    // return aligned runs in the order they were asked for, but nothing in the
+    // response says so, and indexing by position would file a version under
+    // another browser's column the day that changes.
+    for (const product of products) {
+      csvRecord.push(csvField(scored.versions.get(product)));
+      csvRecord.push(formatScore(scored.scores.get(product)));
+    }
+    csvRecord.push(formatScore(scored.interop));
+    data += csvRecord.join(',') + '\n';
+  }
+  return data;
+}
+
+// Returns the per-feature breakdown of one date's |featureScores|, sorted by
+// interop descending then feature ascending, so that rescoring a date
+// reproduces it byte for byte.
+function formatDetailCsv(products, featureScores) {
+  let data = 'feature';
+  for (const product of products) {
+    data += `,${product}`;
+  }
+  data += ',interop,tests\n';
+
+  const features = Array.from(featureScores.keys());
+  features.sort((a, b) => {
+    const byInterop =
+        featureScores.get(b).interop - featureScores.get(a).interop;
+    return byInterop || (a < b ? -1 : 1);
+  });
+
+  for (const feature of features) {
+    const scored = featureScores.get(feature);
+    const csvRecord = [csvField(feature)];
+    for (const product of products) {
+      csvRecord.push(formatScore(scored.scores.get(product)));
+    }
+    csvRecord.push(formatScore(scored.interop));
+    csvRecord.push(scored.tests);
+    data += csvRecord.join(',') + '\n';
+  }
+  return data;
+}
+
+module.exports = {
+  formatAggregateCsv,
+  formatDetailCsv,
+};

--- a/lib/runs.js
+++ b/lib/runs.js
@@ -1,9 +1,11 @@
 'use strict';
 
+const childProcess = require('child_process');
 const fetch = require('node-fetch');
 const fs = require('fs');
 const moment = require('moment');
 const path = require('path');
+const util = require('util');
 const zlib = require('zlib');
 const {advanceDateToSkipBadDataIfNecessary} = require('../bad-ranges');
 
@@ -16,6 +18,14 @@ const RUNS_API = 'https://wpt.fyi/api/runs';
 const WPT_RELEASE_API =
     'https://api.github.com/repos/web-platform-tests/wpt/releases';
 const WEB_FEATURES_MANIFEST_LABEL = 'WEB_FEATURES_MANIFEST.json.gz';
+const WPT_REPO = 'https://github.com/web-platform-tests/wpt';
+
+// One ls-remote of every merge_pr tag is a few megabytes, and an unresponsive
+// remote would otherwise hang a build with no output at all.
+const LS_REMOTE_MAX_BUFFER = 32 * 1024 * 1024;
+const LS_REMOTE_TIMEOUT_MS = 5 * 60 * 1000;
+
+const execFile = util.promisify(childProcess.execFile);
 
 function apiURL(options = {}) {
   const url = new URL(RUNS_API);
@@ -218,12 +228,6 @@ async function fetchWebFeaturesManifestFromURL(releaseURL) {
   return parseWebFeaturesManifest(await assetResponse.buffer());
 }
 
-// Fetches the web features manifest from the latest wpt release and returns a
-// map from feature to the set of tests that make up that feature.
-async function fetchWebFeaturesManifest() {
-  return fetchWebFeaturesManifestFromURL(`${WPT_RELEASE_API}/latest`);
-}
-
 // Fetches the web features manifest from the wpt release tagged |tag|. The
 // caller pins the tag so that a score does not change between builds, which
 // makes a release without the manifest a broken pin rather than a date to skip.
@@ -232,13 +236,74 @@ async function fetchWebFeaturesManifestFromRelease(tag) {
       `${WPT_RELEASE_API}/tags/${tag}`);
 }
 
+// Maps each wpt commit to the merge_pr_* tag on it, from the output of
+// `git ls-remote --tags`.
+//
+// ls-remote lists an annotated tag twice: the tag object under refs/tags/X and
+// the commit it points at under refs/tags/X^{}. Only the peeled line holds the
+// commit, so it wins where present. A lightweight tag, which is what wpt uses
+// today, has only the first line and it is already the commit.
+function parseWptTagMap(lsRemoteOutput) {
+  const tagObjects = new Map();
+  const commits = new Map();
+  for (const line of lsRemoteOutput.split('\n')) {
+    const match = line.match(
+        /^([0-9a-f]{40})\trefs\/tags\/(merge_pr_\d+)(\^\{\})?$/);
+    if (match === null) {
+      continue;
+    }
+    const [, oid, tag, peeled] = match;
+    (peeled === undefined ? tagObjects : commits).set(tag, oid);
+  }
+
+  const tagMap = new Map();
+  for (const [tag, oid] of tagObjects) {
+    tagMap.set(commits.has(tag) ? commits.get(tag) : oid, tag);
+  }
+  return tagMap;
+}
+
+// Fetches every merge_pr_* tag from wpt in one call, which is enough to map a
+// run's revision to its release without cloning wpt. Empty output would skip
+// every date and publish nothing, so it is an error rather than an empty map.
+async function fetchWptTagMap() {
+  const {stdout} = await execFile('git',
+      ['ls-remote', '--tags', WPT_REPO, 'refs/tags/merge_pr_*'],
+      {maxBuffer: LS_REMOTE_MAX_BUFFER, timeout: LS_REMOTE_TIMEOUT_MS});
+  const tagMap = parseWptTagMap(stdout);
+  if (tagMap.size === 0) {
+    throw new Error(`No merge_pr tags found in ${WPT_REPO}`);
+  }
+  return tagMap;
+}
+
+// Fetches the web features manifest built from |revision|, the full 40
+// character hash of the wpt commit a run was on, using the |tagMap| that
+// fetchWptTagMap returns. Returns undefined when that revision has no
+// release, which is a date to skip: scoring it against another revision's
+// manifest would compare a run against a catalogue it never ran from.
+async function fetchWebFeaturesManifestForRevision(revision, tagMap) {
+  if (!/^[0-9a-f]{40}$/.test(revision)) {
+    // wpt.fyi also has a 10 character 'revision' field, which never matches.
+    throw new Error(`Not a full wpt revision hash: '${revision}'`);
+  }
+
+  const tag = tagMap.get(revision);
+  if (tag === undefined) {
+    return undefined;
+  }
+  return fetchWebFeaturesManifestFromRelease(tag);
+}
+
 module.exports = {
   get,
   getAll,
   getIterator,
   fetchAlignedRunsFromServer,
-  fetchWebFeaturesManifest,
+  fetchWebFeaturesManifestForRevision,
   fetchWebFeaturesManifestFromRelease,
+  fetchWptTagMap,
   findWebFeaturesManifestAsset,
   parseWebFeaturesManifest,
+  parseWptTagMap,
 };

--- a/test/interop-csv.js
+++ b/test/interop-csv.js
@@ -1,0 +1,169 @@
+'use strict';
+
+const assert = require('chai').assert;
+
+const interopCsv = require('../lib/interop-csv');
+
+// The products feature-level-interop.js scores by default, so that a column
+// order or a score lookup cannot be right for a pair and wrong for three.
+const PRODUCTS = ['chrome', 'firefox', 'safari'];
+
+// Builds the per-date entry formatAggregateCsv takes, with a score per product
+// in |scores| given in the order of |products|, and |versions| keyed by product
+// as feature-level-interop.js keys them.
+function createScored(products, scores, interop, versions) {
+  return {
+    sha: 'abcdef',
+    manifest: 'merge_pr_12345',
+    versions: new Map(products.map((product, i) => [product, versions[i]])),
+    scores: new Map(products.map((product, i) => [product, scores[i]])),
+    interop,
+  };
+}
+
+// Builds the per-feature entry formatDetailCsv takes.
+function createFeatureScored(scores, interop, tests) {
+  return {
+    scores: new Map(PRODUCTS.map((product, i) => [product, scores[i]])),
+    interop,
+    tests,
+  };
+}
+
+// The dates of the rows in |csv|, in the order they appear.
+function datesIn(csv) {
+  return csv.split('\n').filter(line => line !== '').slice(1)
+      .map(line => line.split(',')[1]);
+}
+
+describe('interop-csv.js', () => {
+  describe('formatAggregateCsv', () => {
+    it('should name a version and a score column per product', () => {
+      const csv = interopCsv.formatAggregateCsv(PRODUCTS, new Map());
+
+      assert.equal(csv,
+          'sha,date,manifest,chrome-version,chrome,firefox-version,firefox,' +
+          'safari-version,safari,interop\n');
+    });
+
+    it('should write a row for the date scored', () => {
+      const rows = new Map([
+        ['2026-02-15', createScored(PRODUCTS, [1, 0.5, 0.25], 0.25,
+            ['140.0', '141.0', '26.3'])],
+      ]);
+
+      assert.equal(interopCsv.formatAggregateCsv(PRODUCTS, rows),
+          'sha,date,manifest,chrome-version,chrome,firefox-version,firefox,' +
+          'safari-version,safari,interop\n' +
+          'abcdef,2026-02-15,merge_pr_12345,140.0,100.0,141.0,50.0,' +
+          '26.3,25.0,25.0\n');
+    });
+
+    it('should keep the order the dates were scored in', () => {
+      // The caller inserts in date order, so the rows come out in it too.
+      const rows = new Map([
+        ['2026-02-15', createScored(['chrome'], [1], 1, ['140.0'])],
+        ['2026-02-16', createScored(['chrome'], [1], 1, ['140.0'])],
+        ['2026-02-17', createScored(['chrome'], [1], 1, ['140.0'])],
+      ]);
+
+      assert.deepEqual(datesIn(interopCsv.formatAggregateCsv(['chrome'], rows)),
+          ['2026-02-15', '2026-02-16', '2026-02-17']);
+    });
+
+    it('should pair a version with its own browser, not its position', () => {
+      // wpt.fyi returns aligned runs in the order they were asked for, but
+      // nothing in the response promises that, so the versions arrive keyed by
+      // browser. Keying them here in the reverse of the column order is what a
+      // positional lookup would file under the wrong browser.
+      const rows = new Map([
+        ['2026-02-15', {
+          sha: 'abcdef',
+          manifest: 'merge_pr_12345',
+          versions: new Map([
+            ['safari', '26.3'],
+            ['firefox', '141.0'],
+            ['chrome', '140.0'],
+          ]),
+          scores: new Map([['chrome', 1], ['firefox', 1], ['safari', 1]]),
+          interop: 1,
+        }],
+      ]);
+
+      assert.equal(interopCsv.formatAggregateCsv(PRODUCTS, rows),
+          'sha,date,manifest,chrome-version,chrome,firefox-version,firefox,' +
+          'safari-version,safari,interop\n' +
+          'abcdef,2026-02-15,merge_pr_12345,140.0,100.0,141.0,100.0,' +
+          '26.3,100.0,100.0\n');
+    });
+
+    it('should quote a browser version holding a comma', () => {
+      // An unquoted comma would add a column and file every later score one
+      // place to the right.
+      const rows = new Map([
+        ['2026-02-15', createScored(PRODUCTS, [1, 1, 1], 1,
+            ['140.0, build 2', '141.0', '26.3'])],
+      ]);
+
+      const csv = interopCsv.formatAggregateCsv(PRODUCTS, rows);
+
+      assert.include(csv.split('\n')[1], '"140.0, build 2"');
+    });
+  });
+
+  describe('formatDetailCsv', () => {
+    it('should write a row per feature with its test count', () => {
+      const featureScores = new Map([
+        ['grid', createFeatureScored([1, 0.5, 0.25], 0.25, 4)],
+      ]);
+
+      assert.equal(interopCsv.formatDetailCsv(PRODUCTS, featureScores),
+          'feature,chrome,firefox,safari,interop,tests\n' +
+          'grid,100.0,50.0,25.0,25.0,4\n');
+    });
+
+    it('should sort by interop descending', () => {
+      const featureScores = new Map([
+        ['grid', createFeatureScored([0.5, 0.5, 0.5], 0.5, 1)],
+        ['flexbox', createFeatureScored([1, 1, 1], 1, 1)],
+      ]);
+
+      const features = interopCsv.formatDetailCsv(PRODUCTS, featureScores)
+          .split('\n').slice(1).filter(l => l).map(l => l.split(',')[0]);
+
+      assert.deepEqual(features, ['flexbox', 'grid']);
+    });
+
+    it('should break an interop tie by feature name ascending', () => {
+      // Insertion order here is the reverse of the wanted order, so a stable
+      // sort that ignored the name would reproduce it.
+      const featureScores = new Map([
+        ['grid', createFeatureScored([1, 1, 1], 1, 1)],
+        ['flexbox', createFeatureScored([1, 1, 1], 1, 1)],
+        ['anchor-positioning', createFeatureScored([1, 1, 1], 1, 1)],
+      ]);
+
+      const features = interopCsv.formatDetailCsv(PRODUCTS, featureScores)
+          .split('\n').slice(1).filter(l => l).map(l => l.split(',')[0]);
+
+      assert.deepEqual(features, ['anchor-positioning', 'flexbox', 'grid']);
+    });
+
+    it('should reproduce the same bytes for the same scores', () => {
+      // Every build scores every date again, so a date has to keep producing
+      // the breakdown that is already published for it.
+      const build = () => new Map([
+        ['grid', createFeatureScored([1, 0.5, 0.25], 0.25, 4)],
+        ['flexbox', createFeatureScored([0.25, 1, 0.5], 0.25, 8)],
+      ]);
+
+      assert.equal(interopCsv.formatDetailCsv(PRODUCTS, build()),
+          interopCsv.formatDetailCsv(PRODUCTS, build()));
+    });
+
+    it('should return only a header when no feature was scored', () => {
+      assert.equal(interopCsv.formatDetailCsv(PRODUCTS, new Map()),
+          'feature,chrome,firefox,safari,interop,tests\n');
+    });
+  });
+});

--- a/test/runs.js
+++ b/test/runs.js
@@ -93,6 +93,52 @@ describe('runs.js', () => {
     });
   });
 
+  describe('parseWptTagMap', () => {
+    it('should map each commit to its tag', () => {
+      const output = [
+        '5ec18b17503524523ff6fe6a6b801512d659a6e5\trefs/tags/merge_pr_57790',
+        '92e4771f00d1ae92e94abf4754249c227252293e\trefs/tags/merge_pr_57791',
+      ].join('\n');
+
+      assert.deepEqual(runs.parseWptTagMap(output), new Map([
+        ['5ec18b17503524523ff6fe6a6b801512d659a6e5', 'merge_pr_57790'],
+        ['92e4771f00d1ae92e94abf4754249c227252293e', 'merge_pr_57791'],
+      ]));
+    });
+
+    it('should key an annotated tag on the peeled commit, not the tag object',
+        () => {
+          // ls-remote prints the tag object under refs/tags/X and the commit it
+          // points at under refs/tags/X^{}. Keying on the first would map a
+          // revision no run is ever on, silently skipping every date.
+          const output = [
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\t' +
+                'refs/tags/merge_pr_57791',
+            '92e4771f00d1ae92e94abf4754249c227252293e\t' +
+                'refs/tags/merge_pr_57791^{}',
+          ].join('\n');
+
+          assert.deepEqual(runs.parseWptTagMap(output), new Map([
+            ['92e4771f00d1ae92e94abf4754249c227252293e', 'merge_pr_57791'],
+          ]));
+        });
+
+    it('should ignore refs that are not merge_pr tags', () => {
+      const output = [
+        '0000000000000000000000000000000000000001\trefs/tags/epochs/daily',
+        '92e4771f00d1ae92e94abf4754249c227252293e\trefs/tags/merge_pr_57791',
+      ].join('\n');
+
+      assert.deepEqual(runs.parseWptTagMap(output), new Map([
+        ['92e4771f00d1ae92e94abf4754249c227252293e', 'merge_pr_57791'],
+      ]));
+    });
+
+    it('should return an empty map for no output', () => {
+      assert.deepEqual(runs.parseWptTagMap(''), new Map());
+    });
+  });
+
   describe('parseWebFeaturesManifest', () => {
     it('should map each feature to its set of tests', () => {
       const manifest = createManifest(1, {


### PR DESCRIPTION
Each date is scored against the manifest from that date's own wpt revision, so
a run is never measured against a catalogue it did not run from. A build writes
one aggregate row per date plus that date's per-feature breakdown, rescoring
every date as browser-specific-failures.js does.
