### PR TITLE
Cache the web features manifest and authenticate its lookup

### DIFF
--- a/.github/workflows/update_gh_pages.yml
+++ b/.github/workflows/update_gh_pages.yml
@@ -28,8 +28,25 @@ jobs:
     - name: Install dependencies
       run: npm ci
 
+    # Every scoring script caches what it fetches under cache/, keyed by
+    # something immutable, so restoring it leaves a build fetching only the
+    # dates and wpt releases that have appeared since the last one. The run id
+    # keeps each key unique, so the cache is always saved back.
+    - name: Restore the fetch cache
+      uses: actions/cache@v4
+      with:
+        path: cache
+        key: results-analysis-fetch-${{ github.run_id }}
+        restore-keys: results-analysis-fetch-
+
     - name: Build
       run: ./build.sh
+      env:
+        # feature-level-interop.js looks a wpt release up for every date it
+        # scores, which does not fit in the 60 requests an hour GitHub allows an
+        # unauthenticated caller. GITHUB_TOKEN raises that to 1000 an hour per
+        # repository, and the cache restored above keeps a build well under it.
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Deploy to gh-pages/
       uses: JamesIves/github-pages-deploy-action@releases/v3

--- a/lib/runs.js
+++ b/lib/runs.js
@@ -210,30 +210,79 @@ function parseWebFeaturesManifest(buffer) {
   return featureTests;
 }
 
-// Fetches the web features manifest at |releaseURL| and
-// returns a map from feature to the set of tests that make up that feature.
-async function fetchWebFeaturesManifestFromURL(releaseURL) {
-  const releaseResponse = await fetch(releaseURL);
+// GitHub allows an unauthenticated caller 60 API requests an hour per IP, and
+// a build looks up a release for every date it scores, so an unauthenticated
+// build runs out inside the first few dates. The workflow passes its own
+// GITHUB_TOKEN, which raises the limit to 1000 an hour per repository; the
+// disk cache below is what keeps a build well clear of that as the range grows.
+function githubApiHeaders() {
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) {
+    return {};
+  }
+  return {Authorization: `Bearer ${token}`};
+}
+
+// Reads a 403 or 429 from the GitHub API as the exhausted rate limit it almost
+// always is, since the bare status reads like a release that is not there.
+function rateLimitHint(response) {
+  if (response.status !== 403 && response.status !== 429) {
+    return '';
+  }
+  if (response.headers.get('x-ratelimit-remaining') !== '0') {
+    return '';
+  }
+  return '. The GitHub API rate limit is exhausted: 60 requests an hour ' +
+      'unauthenticated, or 1000 with GITHUB_TOKEN set';
+}
+
+// Fetches the gzipped web features manifest asset from the release at
+// |releaseURL|. The bytes are returned rather than the parsed map so that the
+// caller can cache exactly what it was served.
+async function fetchWebFeaturesManifestBufferFromURL(releaseURL) {
+  const releaseResponse = await fetch(releaseURL,
+      {headers: githubApiHeaders()});
   if (!releaseResponse.ok) {
     throw new Error(`non-OK fetch status ${releaseResponse.status} when ` +
-        `fetching ${releaseURL}`);
+        `fetching ${releaseURL}${rateLimitHint(releaseResponse)}`);
   }
   const asset = findWebFeaturesManifestAsset(await releaseResponse.json());
 
+  // The download host does not count against the API rate limit and rejects an
+  // Authorization header meant for the API, so this half stays unauthenticated.
   const assetResponse = await fetch(asset['browser_download_url']);
   if (!assetResponse.ok) {
     throw new Error(`non-OK fetch status ${assetResponse.status} when ` +
         `fetching ${asset['browser_download_url']}`);
   }
-  return parseWebFeaturesManifest(await assetResponse.buffer());
+  return assetResponse.buffer();
+}
+
+// Names the disk cache file holding the manifest asset published for |tag|.
+// parseWptTagMap only yields merge_pr_* tags, so |tag| is safe in a path.
+function manifestCacheFile(tag) {
+  return path.join(__dirname, '..', 'cache',
+      `${tag}-${WEB_FEATURES_MANIFEST_LABEL}`);
 }
 
 // Fetches the web features manifest from the wpt release tagged |tag|. The
 // caller pins the tag so that a score does not change between builds, which
 // makes a release without the manifest a broken pin rather than a date to skip.
+//
+// A build looks a manifest up for every date it scores, far more requests than
+// the GitHub API allows, so the asset is cached on disk as the runs above are.
+// A published asset never changes, so a hit needs no staleness check.
 async function fetchWebFeaturesManifestFromRelease(tag) {
-  return fetchWebFeaturesManifestFromURL(
-      `${WPT_RELEASE_API}/tags/${tag}`);
+  const cacheFile = manifestCacheFile(tag);
+  try {
+    return parseWebFeaturesManifest(await fs.promises.readFile(cacheFile));
+  } catch (e) {
+    // No cache hit, or a file we can no longer read; fetch the asset instead.
+    const buffer = await fetchWebFeaturesManifestBufferFromURL(
+        `${WPT_RELEASE_API}/tags/${tag}`);
+    await fs.promises.writeFile(cacheFile, buffer);
+    return parseWebFeaturesManifest(buffer);
+  }
 }
 
 // Maps each wpt commit to the merge_pr_* tag on it, from the output of


### PR DESCRIPTION
feature-level-interop.js looks a wpt release up for every date it scores,
which is hundreds of GitHub API requests a build against the 60 an hour an
unauthenticated caller is allowed. Once build.sh runs it, a build would fail
partway through and publish nothing at all, taking the
browser-specific-failures and interop year CSVs down with it.

The manifest asset is now cached under cache/ keyed by its release tag, as
the runs above it are, and the workflow both passes its own GITHUB_TOKEN and
restores cache/ between builds, so a build fetches only the releases that
have appeared since the last one.
