### PR TITLE
Publish feature-level interop scores

### DIFF
--- a/.github/workflows/update_gh_pages.yml
+++ b/.github/workflows/update_gh_pages.yml
@@ -30,6 +30,8 @@ jobs:
 
     - name: Build
       run: ./build.sh
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Deploy to gh-pages/
       uses: JamesIves/github-pages-deploy-action@releases/v3

--- a/build.sh
+++ b/build.sh
@@ -43,24 +43,19 @@ update_bsf_csv out/data/experimental-browser-specific-failures.csv
 update_bsf_csv out/data/stable-browser-specific-failures-with-third-party.csv
 update_bsf_csv out/data/experimental-browser-specific-failures-with-third-party.csv
 
-# TODO: Call update_feature_level_interop_csv once feature-level-interop.js
-# scores the runs and writes a CSV. It currently only loads the aligned runs,
-# their result trees and the web features manifest, so running it here would
-# cost a full load of every run without producing any output.
 update_feature_level_interop_csv() {
-  local OUTPUT="${1}"
-
-  local FROM_DATE="2018-06-01"
-  local EXPERIMENTAL_FLAG=""
-  if [[ $1 == *"experimental"* ]]; then
-    EXPERIMENTAL_FLAG="--experimental"
-  fi
+  # The web features catalogue first settled on this date.
+  # Measuring before this date would measure cataloguing progress as much as browser progress.
+  local FROM_DATE="2026-01-28"
 
   node feature-level-interop.js \
-    ${EXPERIMENTAL_FLAG} \
-    --from=${FROM_DATE} --to=${TO_DATE} \
-    --output=${OUTPUT}
+    --experimental \
+    --from=${FROM_DATE} --to=${TO_DATE}
+
+  node feature-level-interop.js \
+    --from=${FROM_DATE} --to=${TO_DATE}
 }
+update_feature_level_interop_csv
 
 update_interop_year() {
   local YEAR="${1}"

--- a/feature-level-interop.js
+++ b/feature-level-interop.js
@@ -119,6 +119,7 @@ async function main() {
         versions,
         scores: averaged.scores,
         interop: averaged.interop,
+        features: averaged.features,
       });
     } catch (e) {
       e.message += `\n\tRuns: ${runs.map(r => r.id)}`;

--- a/lib/interop-csv.js
+++ b/lib/interop-csv.js
@@ -29,7 +29,7 @@ function formatAggregateCsv(products, dateToScores) {
   for (const product of products) {
     data += `,${product}-version,${product}`;
   }
-  data += ',interop\n';
+  data += ',interop,features\n';
 
   // ES6 maps iterate in insertion order, and we initially inserted in date
   // order, so we can just iterate |dateToScores|.
@@ -48,6 +48,7 @@ function formatAggregateCsv(products, dateToScores) {
       csvRecord.push(formatScore(scored.scores.get(product)));
     }
     csvRecord.push(formatScore(scored.interop));
+    csvRecord.push(scored.features);
     data += csvRecord.join(',') + '\n';
   }
   return data;

--- a/lib/runs.js
+++ b/lib/runs.js
@@ -210,16 +210,40 @@ function parseWebFeaturesManifest(buffer) {
   return featureTests;
 }
 
+function githubApiHeaders() {
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) {
+    return {};
+  }
+  return {Authorization: `Bearer ${token}`};
+}
+
+// Reads a 403 or 429 from the GitHub API as the exhausted rate limit it almost
+// always is, since the bare status reads like a release that is not there.
+function rateLimitHint(response) {
+  if (response.status !== 403 && response.status !== 429) {
+    return '';
+  }
+  if (response.headers.get('x-ratelimit-remaining') !== '0') {
+    return '';
+  }
+  return '. The GitHub API rate limit is exhausted: 60 requests an hour ' +
+      'unauthenticated, or 1000 with GITHUB_TOKEN set';
+}
+
 // Fetches the web features manifest at |releaseURL| and
 // returns a map from feature to the set of tests that make up that feature.
 async function fetchWebFeaturesManifestFromURL(releaseURL) {
-  const releaseResponse = await fetch(releaseURL);
+  const releaseResponse = await fetch(releaseURL,
+      {headers: githubApiHeaders()});
   if (!releaseResponse.ok) {
     throw new Error(`non-OK fetch status ${releaseResponse.status} when ` +
-        `fetching ${releaseURL}`);
+        `fetching ${releaseURL}${rateLimitHint(releaseResponse)}`);
   }
   const asset = findWebFeaturesManifestAsset(await releaseResponse.json());
 
+  // The download host does not count against the API rate limit and rejects an
+  // Authorization header meant for the API, so this half stays unauthenticated.
   const assetResponse = await fetch(asset['browser_download_url']);
   if (!assetResponse.ok) {
     throw new Error(`non-OK fetch status ${assetResponse.status} when ` +

--- a/test/interop-csv.js
+++ b/test/interop-csv.js
@@ -9,15 +9,16 @@ const interopCsv = require('../lib/interop-csv');
 const PRODUCTS = ['chrome', 'firefox', 'safari'];
 
 // Builds the per-date entry formatAggregateCsv takes, with a score per product
-// in |scores| given in the order of |products|, and |versions| keyed by product
-// as feature-level-interop.js keys them.
-function createScored(products, scores, interop, versions) {
+// in |scores| given in the order of |products|, |versions| keyed by product as
+// feature-level-interop.js keys them, and |features| of them scored.
+function createScored(products, scores, interop, versions, features) {
   return {
     sha: 'abcdef',
     manifest: 'merge_pr_12345',
     versions: new Map(products.map((product, i) => [product, versions[i]])),
     scores: new Map(products.map((product, i) => [product, scores[i]])),
     interop,
+    features,
   };
 }
 
@@ -43,28 +44,45 @@ describe('interop-csv.js', () => {
 
       assert.equal(csv,
           'sha,date,manifest,chrome-version,chrome,firefox-version,firefox,' +
-          'safari-version,safari,interop\n');
+          'safari-version,safari,interop,features\n');
     });
 
     it('should write a row for the date scored', () => {
       const rows = new Map([
         ['2026-02-15', createScored(PRODUCTS, [1, 0.5, 0.25], 0.25,
-            ['140.0', '141.0', '26.3'])],
+            ['140.0', '141.0', '26.3'], 7)],
       ]);
 
       assert.equal(interopCsv.formatAggregateCsv(PRODUCTS, rows),
           'sha,date,manifest,chrome-version,chrome,firefox-version,firefox,' +
-          'safari-version,safari,interop\n' +
+          'safari-version,safari,interop,features\n' +
           'abcdef,2026-02-15,merge_pr_12345,140.0,100.0,141.0,50.0,' +
-          '26.3,25.0,25.0\n');
+          '26.3,25.0,25.0,7\n');
+    });
+
+    it('should write the count of features scored for the date', () => {
+      // The count moves between dates, so it cannot be written once for the
+      // file; a reader hovering a point is told what that date averaged.
+      const rows = new Map([
+        ['2026-02-15', createScored(PRODUCTS, [1, 1, 1], 1,
+            ['140.0', '141.0', '26.3'], 412)],
+        ['2026-02-22', createScored(PRODUCTS, [1, 1, 1], 1,
+            ['140.0', '141.0', '26.3'], 415)],
+      ]);
+
+      const counts = interopCsv.formatAggregateCsv(PRODUCTS, rows)
+          .split('\n').filter(line => line !== '').slice(1)
+          .map(line => line.split(',').pop());
+
+      assert.deepEqual(counts, ['412', '415']);
     });
 
     it('should keep the order the dates were scored in', () => {
       // The caller inserts in date order, so the rows come out in it too.
       const rows = new Map([
-        ['2026-02-15', createScored(['chrome'], [1], 1, ['140.0'])],
-        ['2026-02-16', createScored(['chrome'], [1], 1, ['140.0'])],
-        ['2026-02-17', createScored(['chrome'], [1], 1, ['140.0'])],
+        ['2026-02-15', createScored(['chrome'], [1], 1, ['140.0'], 7)],
+        ['2026-02-16', createScored(['chrome'], [1], 1, ['140.0'], 7)],
+        ['2026-02-17', createScored(['chrome'], [1], 1, ['140.0'], 7)],
       ]);
 
       assert.deepEqual(datesIn(interopCsv.formatAggregateCsv(['chrome'], rows)),
@@ -87,14 +105,15 @@ describe('interop-csv.js', () => {
           ]),
           scores: new Map([['chrome', 1], ['firefox', 1], ['safari', 1]]),
           interop: 1,
+          features: 7,
         }],
       ]);
 
       assert.equal(interopCsv.formatAggregateCsv(PRODUCTS, rows),
           'sha,date,manifest,chrome-version,chrome,firefox-version,firefox,' +
-          'safari-version,safari,interop\n' +
+          'safari-version,safari,interop,features\n' +
           'abcdef,2026-02-15,merge_pr_12345,140.0,100.0,141.0,100.0,' +
-          '26.3,100.0,100.0\n');
+          '26.3,100.0,100.0,7\n');
     });
 
     it('should quote a browser version holding a comma', () => {
@@ -102,7 +121,7 @@ describe('interop-csv.js', () => {
       // place to the right.
       const rows = new Map([
         ['2026-02-15', createScored(PRODUCTS, [1, 1, 1], 1,
-            ['140.0, build 2', '141.0', '26.3'])],
+            ['140.0, build 2', '141.0', '26.3'], 7)],
       ]);
 
       const csv = interopCsv.formatAggregateCsv(PRODUCTS, rows);


### PR DESCRIPTION
build.sh now generates feature level interop scores for stable and experimental channels from the date the web features catalogue settled.

Every build rescores the whole range and writes every CSV from scratch, as the browser-specific-failures scoring above it does, so nothing depends on what a previous build published.

This change also adds a GITHUB_TOKEN to the workflow to raise the rate limit for GitHub API requests. This is needed as a separate API request is needed per date to fetch the manifest and test results for scoring.

The aggregate CSV carries the count of features scored for each date, which the interop graph on WPT.FYI will later use in a hover tooltip. This count moves as wpt changes its feature annotations, so it belongs in the row rather than being inferred by the consumer.